### PR TITLE
refactor: инициализация DI и поиск устройств перенесены в lifespan

### DIFF
--- a/src/api/endpoints/api_service.py
+++ b/src/api/endpoints/api_service.py
@@ -1,33 +1,33 @@
 import asyncio
 from logging import getLogger
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
-from core.dependencies.main_di_container import MainDIContainer
 from main_stream_service.main_stream_manager import MainStreamManager
 
 logger = getLogger(__name__)
 
 router = APIRouter()
 
-di_container = MainDIContainer().get_container()
-
-main_stream_manager = di_container.get(MainStreamManager)
-
 # Ссылка на задачу запуска, чтобы её не собрал сборщик мусора
 _start_task: asyncio.Task | None = None
 
 
+def _get_manager(request: Request) -> MainStreamManager:
+    """Возвращает MainStreamManager, созданный в lifespan приложения."""
+    return request.app.state.main_stream_manager
+
+
 @router.post("/stream_on")
-async def stream_on():
+async def stream_on(request: Request):
     """API-команда для запуска стрима."""
     global _start_task
-    _start_task = asyncio.create_task(main_stream_manager.start())
+    _start_task = asyncio.create_task(_get_manager(request).start())
     return {"status": "stream_on"}
 
 
 @router.post("/shutdown")
-async def shutdown():
+async def shutdown(request: Request):
     """API-команда для остановки стрима."""
-    await main_stream_manager.stop()
+    await _get_manager(request).stop()
     return {"status": "main_service stopped"}

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,22 +1,37 @@
+from contextlib import asynccontextmanager
 from logging import getLogger
+from typing import AsyncIterator
 
 import uvicorn
 from fastapi import FastAPI
 
 from api.endpoints.routers import main_router
 from core.config.settings import settings
+from core.dependencies.main_di_container import MainDIContainer
 from core.logging.setup import setup_logging
+from main_stream_service.main_stream_manager import MainStreamManager
 
 setup_logging()
 
 logger = getLogger(__name__)
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Создание DI-контейнера и менеджера стриминга при старте."""
+    container = MainDIContainer().get_container()
+    app.state.main_stream_manager = container.get(MainStreamManager)
+    logger.info("✅ Зависимости API сервиса инициализированы")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(main_router)
 
 
 def main():
+    """Запускает API сервер управления стримингом."""
     logger.info("▶️ Запуск API сервера...")
     uvicorn.run(
         app,

--- a/src/core/dependencies/di_modules.py
+++ b/src/core/dependencies/di_modules.py
@@ -46,8 +46,10 @@ class YandexStationClientModule(Module):
 
     @singleton
     @provider
-    def provide_yandex_station_client(self) -> YandexStationClient:
-        return YandexStationClient(device_finder=DeviceFinder())
+    def provide_yandex_station_client(
+        self, device_finder: DeviceFinder
+    ) -> YandexStationClient:
+        return YandexStationClient(device_finder=device_finder)
 
 
 class YandexStationControlsModule(Module):

--- a/src/dlna_stream_server/endpoints/stream.py
+++ b/src/dlna_stream_server/endpoints/stream.py
@@ -3,7 +3,6 @@ from logging import getLogger
 
 from fastapi import APIRouter, Request, Response
 
-from core.dependencies.main_di_container import MainDIContainer
 from dlna_stream_server.handlers.stream_handler import StreamHandler
 from dlna_stream_server.handlers.utils import ruark_r5_request_logger
 
@@ -12,16 +11,20 @@ logger = getLogger(__name__)
 
 router = APIRouter()
 
-di_container = MainDIContainer().get_container()
-
-stream_handler = di_container.get(StreamHandler)
-
 # Словарь для отслеживания активных задач
 _active_tasks = {}
 
 
+def _get_stream_handler(request: Request) -> StreamHandler:
+    """Возвращает StreamHandler, созданный в lifespan приложения."""
+    return request.app.state.stream_handler
+
+
 async def _handle_stream_task(
-    yandex_url: str, task_id: str, radio: bool = False
+    stream_handler: StreamHandler,
+    yandex_url: str,
+    task_id: str,
+    radio: bool = False,
 ):
     """Обработчик задачи потока с логированием ошибок."""
     try:
@@ -35,7 +38,7 @@ async def _handle_stream_task(
 
 
 @router.post("/set_stream")
-async def set_stream(yandex_url: str, radio: bool = False):
+async def set_stream(request: Request, yandex_url: str, radio: bool = False):
     """Принимает URL трека и запускает потоковую передачу на Ruark."""
     logger.info(f"📥 Запуск нового потока с {yandex_url}")
 
@@ -50,7 +53,11 @@ async def set_stream(yandex_url: str, radio: bool = False):
         _active_tasks.pop(old_task_id, None)
 
     # Запускаем новую задачу
-    task = asyncio.create_task(_handle_stream_task(yandex_url, task_id, radio))
+    task = asyncio.create_task(
+        _handle_stream_task(
+            _get_stream_handler(request), yandex_url, task_id, radio
+        )
+    )
     _active_tasks[task_id] = task
 
     return {
@@ -64,7 +71,7 @@ async def set_stream(yandex_url: str, radio: bool = False):
 async def serve_stream(request: Request, radio: bool = False):
     """Раздает потоковый аудиофайл через HTTP."""
     await ruark_r5_request_logger(request)
-    return await stream_handler.stream_audio(radio)
+    return await _get_stream_handler(request).stream_audio(radio)
 
 
 @router.head("/live_stream.mp3")
@@ -79,8 +86,8 @@ async def serve_head(radio: bool = False):
 
 
 @router.post("/stop_stream")
-async def stop_stream():
+async def stop_stream(request: Request):
     """Останавливает потоковую передачу на Ruark."""
     logger.info("🛑 Остановка потоковой передачи...")
-    await stream_handler.stop_ffmpeg()
+    await _get_stream_handler(request).stop_ffmpeg()
     return {"message": "Потоковая передача остановлена"}

--- a/src/dlna_stream_server/main.py
+++ b/src/dlna_stream_server/main.py
@@ -1,22 +1,47 @@
+import asyncio
+from contextlib import asynccontextmanager
 from logging import getLogger
+from typing import AsyncIterator
 
 import uvicorn
 from fastapi import FastAPI
 
 from core.config.settings import settings
+from core.dependencies.main_di_container import MainDIContainer
 from core.logging.setup import setup_logging
 from dlna_stream_server.endpoints.routers import main_router
+from dlna_stream_server.handlers.stream_handler import StreamHandler
+from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 
 setup_logging()
 
 logger = getLogger(__name__)
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Инициализация зависимостей и фоновый поиск Ruark при старте."""
+    container = MainDIContainer().get_container()
+    app.state.stream_handler = container.get(StreamHandler)
+    ruark = container.get(RuarkR5Controller)
+    connect_task = asyncio.create_task(ruark.connect())
+    logger.info("✅ Зависимости DLNA сервера инициализированы")
+
+    yield
+
+    if not connect_task.done():
+        connect_task.cancel()
+    await app.state.stream_handler.stop_ffmpeg()
+    logger.info("⏹ DLNA сервер остановлен")
+
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(main_router)
 
 
 def main():
+    """Запускает DLNA стриминговый сервер."""
     logger.info("▶️ Запуск dlna стримингового сервера...")
     uvicorn.run(
         app,

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -6,6 +6,7 @@ from injector import inject
 
 from core.config.settings import settings
 from main_stream_service.yandex_music_api import YandexMusicAPI
+from ruark_audio_system.exceptions import RuarkDeviceNotFoundError
 from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 from yandex_station.constants import (
     ALICE_ACTIVE_STATES,
@@ -56,11 +57,21 @@ class MainStreamManager:
             return
 
         logger.info("🎵 Запуск стриминга")
-        self._stream_state_running = True
+        try:
+            # Поиск устройств выполняется здесь, а не при старте процесса
+            if not await self._ruark_controls.connect():
+                raise RuarkDeviceNotFoundError(
+                    f"Устройство "
+                    f"'{self._ruark_controls.device_name}' "
+                    f"не найдено в сети"
+                )
+            logger.info("🔄 Запуск WebSocket клиента")
+            await self._station_controls.start_ws_client()
+        except Exception as e:
+            logger.error(f"❌ Не удалось запустить стриминг: {e}")
+            return
 
-        # Запуск WebSocket-клиента
-        logger.info("🔄 Запуск WebSocket клиента")
-        await self._station_controls.start_ws_client()
+        self._stream_state_running = True
         logger.info("🎬 Запуск обёртки стриминга")
         stream_task = asyncio.create_task(self._wrap_streaming())
         logger.info("✅ WebSocket клиент запущен")

--- a/src/ruark_audio_system/exceptions.py
+++ b/src/ruark_audio_system/exceptions.py
@@ -1,0 +1,4 @@
+class RuarkDeviceNotFoundError(Exception):
+    """Исключение, если устройство Ruark не найдено в сети."""
+
+    pass

--- a/src/ruark_audio_system/ruark_r5_controller.py
+++ b/src/ruark_audio_system/ruark_r5_controller.py
@@ -9,6 +9,7 @@ import upnpclient
 
 from core.config.settings import settings
 from ruark_audio_system.constants import META_INFO
+from ruark_audio_system.exceptions import RuarkDeviceNotFoundError
 
 SESSION_ID_REGEX = re.compile(r"<sessionId>(.*?)</sessionId>")
 POWER_STATUS_REGEX = re.compile(r"<value><u8>(.*?)</u8></value>")
@@ -26,17 +27,79 @@ class RuarkR5Controller:
     _session_id: str
 
     def __init__(self, device_name: str = "Ruark R5") -> None:
-        """Инициализация и поиск устройства Ruark R5 в сети."""
+        """Сохраняет имя устройства; поиск в сети выполняется в connect()."""
         self.device_name = device_name
-        self.refresh_device()
-        self.print_available_services()
+        self.device: Optional[upnpclient.Device] = None
+        self.ip: Optional[str] = None
+        self.services: Dict[str, Any] = {}
+        self._av_transport: Any = None
+        self._connection_manager: Any = None
+        self._rendering_control: Any = None
+
+    @property
+    def av_transport(self) -> Any:
+        """Сервис AVTransport найденного устройства."""
+        return self._require_service(self._av_transport, "AVTransport")
+
+    @property
+    def connection_manager(self) -> Any:
+        """Сервис ConnectionManager найденного устройства."""
+        return self._require_service(
+            self._connection_manager, "ConnectionManager"
+        )
+
+    @property
+    def rendering_control(self) -> Any:
+        """Сервис RenderingControl найденного устройства."""
+        return self._require_service(
+            self._rendering_control, "RenderingControl"
+        )
+
+    def _require_service(self, service: Any, name: str) -> Any:
+        """Возвращает сервис или бросает ошибку, если устройство не найдено.
+
+        Raises:
+            RuarkDeviceNotFoundError: Если устройство ещё не найдено в сети.
+        """
+        if service is None:
+            raise RuarkDeviceNotFoundError(
+                f"Устройство '{self.device_name}' не найдено в сети — "
+                f"сервис {name} недоступен, вызовите connect()"
+            )
+        return service
+
+    async def connect(self, attempts: int = 3, delay: float = 2.0) -> bool:
+        """Ищет устройство в сети с несколькими попытками.
+
+        Args:
+            attempts (int): Количество попыток поиска.
+            delay (float): Пауза между попытками в секундах.
+        Returns:
+            bool: True, если устройство найдено.
+        """
+        if self.device:
+            return True
+
+        for attempt in range(1, attempts + 1):
+            logger.info(
+                f"🔍 Поиск {self.device_name}: попытка {attempt}/{attempts}"
+            )
+            await asyncio.to_thread(self.refresh_device)
+            if self.device:
+                self.print_available_services()
+                return True
+            if attempt < attempts:
+                await asyncio.sleep(delay)
+
+        logger.error(
+            f"❌ {self.device_name} не найден после {attempts} попыток"
+        )
+        return False
 
     def refresh_device(self) -> None:
         """Обновление устройства."""
         logger.info("🔄 Обновление устройства")
-        self.device: Optional[upnpclient.Device] = self.find_device(
-            device_name=self.device_name
-        )
+        self.device = self.find_device(device_name=self.device_name)
         if not self.device:
             logger.warning(
                 f"⚠ Устройство '{self.device_name}' не найдено в сети!"
@@ -44,16 +107,16 @@ class RuarkR5Controller:
             return
 
         self.ip = self.get_device_ip()
-        self.services: Dict[str, Any] = {
+        self.services = {
             service.service_type: service for service in self.device.services
         }
-        self.av_transport = self.services.get(
+        self._av_transport = self.services.get(
             "urn:schemas-upnp-org:service:AVTransport:1"
         )
-        self.connection_manager = self.services.get(
+        self._connection_manager = self.services.get(
             "urn:schemas-upnp-org:service:ConnectionManager:1"
         )
-        self.rendering_control = self.services.get(
+        self._rendering_control = self.services.get(
             "urn:schemas-upnp-org:service:RenderingControl:1"
         )
         logger.info(

--- a/src/yandex_station/exceptions.py
+++ b/src/yandex_station/exceptions.py
@@ -2,3 +2,9 @@ class ClientNotRunningError(Exception):
     """Исключение, если попытка отправить команду при остановленном клиенте."""
 
     pass
+
+
+class StationNotFoundError(Exception):
+    """Исключение, если Яндекс Станция не найдена в сети."""
+
+    pass

--- a/src/yandex_station/mdns_device_finder.py
+++ b/src/yandex_station/mdns_device_finder.py
@@ -1,6 +1,6 @@
 import ipaddress
 from logging import getLogger
-from time import sleep
+from time import monotonic, sleep
 
 from zeroconf import (
     ServiceBrowser,
@@ -18,13 +18,33 @@ class DeviceFinder(ServiceListener):
     def __init__(self):
         self.device = {}
         self.zeroconf = Zeroconf()
+        self.browser: ServiceBrowser | None = None
 
-    def find_devices(self, type_="_yandexio._tcp.local."):
-        """Поиск устройств Yandex Station в сети."""
-        self.browser = ServiceBrowser(
-            zc=self.zeroconf, type_=type_, handlers=[self._handler_device]
-        )
-        sleep(1)
+    def find_devices(
+        self,
+        type_: str = "_yandexio._tcp.local.",
+        timeout: float = 5.0,
+    ) -> bool:
+        """Ищет устройство Yandex Station не дольше timeout секунд.
+
+        Блокирующий вызов, запускать через asyncio.to_thread.
+
+        Args:
+            type_ (str): Тип mDNS-сервиса для поиска.
+            timeout (float): Максимальное время ожидания в секундах.
+        Returns:
+            bool: True, если устройство найдено.
+        """
+        if self.device:
+            return True
+        if self.browser is None:
+            self.browser = ServiceBrowser(
+                zc=self.zeroconf, type_=type_, handlers=[self._handler_device]
+            )
+        deadline = monotonic() + timeout
+        while not self.device and monotonic() < deadline:
+            sleep(0.1)
+        return bool(self.device)
 
     def _handler_device(
         self,

--- a/src/yandex_station/station_ws_control.py
+++ b/src/yandex_station/station_ws_control.py
@@ -13,7 +13,10 @@ from injector import inject
 
 from core.authorization.yandex_tokens import get_device_token
 from yandex_station.constants import SOCKET_RECONNECT_DELAY
-from yandex_station.exceptions import ClientNotRunningError
+from yandex_station.exceptions import (
+    ClientNotRunningError,
+    StationNotFoundError,
+)
 from yandex_station.mdns_device_finder import DeviceFinder
 
 logger = logging.getLogger(__name__)
@@ -44,13 +47,33 @@ class YandexStationClient:
         self._connected_at = None
         self.tasks = []  # Хранение фоновых задач
 
-        self.device_finder.find_devices()  # Поиск устройств Yandex в сети
-        self.device_id = self.device_finder.device["device_id"]
-        self.platform = self.device_finder.device["platform"]
-        self.uri = (
-            f"wss://{self.device_finder.device['host']}:"
-            f"{self.device_finder.device['port']}"
-        )
+        # Параметры станции заполняются в _ensure_device при запуске
+        self.device_id: str | None = None
+        self.platform: str | None = None
+        self.uri: str | None = None
+
+    async def _ensure_device(self) -> None:
+        """Находит станцию в сети, если она ещё не найдена.
+
+        Raises:
+            StationNotFoundError: Если станция не найдена за отведённое время.
+        """
+        if self.device_id:
+            return
+
+        logger.info("🔍 Поиск Яндекс Станции в сети...")
+        found = await asyncio.to_thread(self.device_finder.find_devices)
+        if not found:
+            raise StationNotFoundError(
+                "Яндекс Станция не найдена в сети "
+                "(mDNS-сервис _yandexio._tcp.local.)"
+            )
+
+        device = self.device_finder.device
+        self.device_id = device["device_id"]
+        self.platform = device["platform"]
+        self.uri = f"wss://{device['host']}:{device['port']}"
+        logger.info(f"✅ Станция найдена: {self.uri}")
 
     async def run_once(self):
         """Гарантированный однократный запуск WebSocket."""
@@ -58,6 +81,7 @@ class YandexStationClient:
             logger.warning("⚠️ WebSocket уже запущен")
             return
 
+        await self._ensure_device()
         logger.info("🚀 Запуск WebSocket-клиента в новой задаче")
         self._connect_task = asyncio.create_task(self.connect())
         self._check_duplicate_tasks()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,17 +6,20 @@ from yandex_station.station_ws_control import YandexStationClient
 
 
 @pytest.fixture
-def mock_station_client():
-    mock_finder = MagicMock()
-    mock_finder.find_devices.side_effect = lambda: setattr(
-        mock_finder,
-        "device",
-        {
-            "device_id": "dummy_id",
-            "platform": "dummy_platform",
-            "host": "localhost",
-            "port": 1234,
-        },
-    )
-    client = YandexStationClient(device_finder=mock_finder)
-    return client
+def mock_finder():
+    """Мок DeviceFinder с найденной станцией."""
+    finder = MagicMock()
+    finder.device = {
+        "device_id": "dummy_id",
+        "platform": "dummy_platform",
+        "host": "localhost",
+        "port": 1234,
+    }
+    finder.find_devices.return_value = True
+    return finder
+
+
+@pytest.fixture
+def mock_station_client(mock_finder):
+    """Клиент станции с замоканным DeviceFinder."""
+    return YandexStationClient(device_finder=mock_finder)

--- a/tests/test_device_init.py
+++ b/tests/test_device_init.py
@@ -1,0 +1,90 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ruark_audio_system.exceptions import RuarkDeviceNotFoundError
+from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
+from yandex_station.exceptions import StationNotFoundError
+from yandex_station.station_ws_control import YandexStationClient
+
+
+def test_station_client_init_does_not_search_network():
+    finder = MagicMock()
+    client = YandexStationClient(device_finder=finder)
+
+    finder.find_devices.assert_not_called()
+    assert client.device_id is None
+    assert client.uri is None
+
+
+async def test_ensure_device_fills_station_params(mock_station_client):
+    await mock_station_client._ensure_device()
+
+    assert mock_station_client.device_id == "dummy_id"
+    assert mock_station_client.platform == "dummy_platform"
+    assert mock_station_client.uri == "wss://localhost:1234"
+
+
+async def test_ensure_device_searches_only_once(mock_station_client):
+    await mock_station_client._ensure_device()
+    await mock_station_client._ensure_device()
+
+    mock_station_client.device_finder.find_devices.assert_called_once()
+
+
+async def test_ensure_device_raises_when_station_not_found():
+    finder = MagicMock()
+    finder.device = {}
+    finder.find_devices.return_value = False
+    client = YandexStationClient(device_finder=finder)
+
+    with pytest.raises(StationNotFoundError):
+        await client._ensure_device()
+
+
+def test_ruark_init_does_not_search_network():
+    controller = RuarkR5Controller()
+
+    assert controller.device is None
+    assert controller.services == {}
+
+
+def test_ruark_service_property_raises_until_connected():
+    controller = RuarkR5Controller()
+
+    with pytest.raises(RuarkDeviceNotFoundError):
+        controller.av_transport
+
+
+async def test_ruark_connect_retries_until_device_found():
+    controller = RuarkR5Controller()
+    fake_device = MagicMock()
+    calls = {"count": 0}
+
+    def refresh_side_effect():
+        calls["count"] += 1
+        if calls["count"] >= 2:
+            controller.device = fake_device
+
+    controller.refresh_device = MagicMock(side_effect=refresh_side_effect)
+    controller.print_available_services = MagicMock()
+
+    assert await controller.connect(attempts=3, delay=0) is True
+    assert controller.refresh_device.call_count == 2
+
+
+async def test_ruark_connect_returns_false_after_all_attempts():
+    controller = RuarkR5Controller()
+    controller.refresh_device = MagicMock()
+
+    assert await controller.connect(attempts=2, delay=0) is False
+    assert controller.refresh_device.call_count == 2
+
+
+async def test_ruark_connect_skips_search_when_already_connected():
+    controller = RuarkR5Controller()
+    controller.device = MagicMock()
+    controller.refresh_device = MagicMock()
+
+    assert await controller.connect() is True
+    controller.refresh_device.assert_not_called()


### PR DESCRIPTION
## Что сделано

Этап 3 рефакторинга: сервисы больше не выполняют сетевые сканы при импорте модулей и не падают при недоступных устройствах. Проверено на живой системе (старт сервисов, /stream_on, трек, радио, /shutdown).

### Изменения
- DI-контейнер и получение `StreamHandler`/`MainStreamManager` перенесены из module-level эндпоинтов в `lifespan` FastAPI, доступ через `app.state`
- конструкторы `RuarkR5Controller` и `YandexStationClient` стали дешёвыми: сетевые сканы убраны из `__init__`, импорт обоих приложений — 0.4 с вместо ~7 с
- `RuarkR5Controller.connect()` — поиск с повторными попытками через `asyncio.to_thread`; UPnP-сервисы защищены свойствами с `RuarkDeviceNotFoundError`
- `YandexStationClient._ensure_device()` — поиск станции при запуске стриминга с ошибкой `StationNotFoundError` вместо `KeyError` в конструкторе
- `DeviceFinder.find_devices()` ищет с таймаутом и опросом вместо фиксированного `sleep(1)`, повторные вызовы переиспользуют `ServiceBrowser`
- `MainStreamManager.start()` подключает Ruark перед запуском и логирует понятную ошибку вместо молчаливой смерти фоновой задачи
- в `lifespan` DLNA сервера поиск Ruark идёт фоновой задачей, при остановке гасится FFmpeg

### Поведение при недоступных устройствах
Раньше: процесс падал до старта HTTP-сервера. Теперь: сервер стартует всегда, поиск повторяется при `/stream_on`, ошибки видны в логах.