### PR TITLE
refactor: строгая типизация и контракт ошибок

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,20 +49,11 @@ warn_redundant_casts = true
 warn_unused_ignores = true
 warn_unreachable = true
 
-# TODO(этап 4): по мере выправления аннотаций убирать коды из
-# disable_error_code, затем включить check_untyped_defs,
-# disallow_any_generics и strict-режим по слоям.
-disable_error_code = [
-    "union-attr",
-    "assignment",
-    "attr-defined",
-    "return-value",
-    "var-annotated",
-    "call-arg",
-    "return",
-    "arg-type",
-]
+plugins = ["pydantic.mypy"]
+
+check_untyped_defs = true
+disallow_any_generics = true
 
 [[tool.mypy.overrides]]
-module = ["upnpclient", "yandex_music", "yandex_music.*"]
+module = ["upnpclient", "yandex_music"]
 ignore_missing_imports = true

--- a/src/api/endpoints/api_service.py
+++ b/src/api/endpoints/api_service.py
@@ -10,7 +10,7 @@ logger = getLogger(__name__)
 router = APIRouter()
 
 # Ссылка на задачу запуска, чтобы её не собрал сборщик мусора
-_start_task: asyncio.Task | None = None
+_start_task: asyncio.Task[None] | None = None
 
 
 def _get_manager(request: Request) -> MainStreamManager:

--- a/src/core/authorization/exceptions.py
+++ b/src/core/authorization/exceptions.py
@@ -1,0 +1,4 @@
+class TokenRequestError(Exception):
+    """Исключение, если не удалось получить токен устройства."""
+
+    pass

--- a/src/core/authorization/yandex_tokens.py
+++ b/src/core/authorization/yandex_tokens.py
@@ -2,12 +2,23 @@ import logging
 
 import aiohttp
 
+from core.authorization.exceptions import TokenRequestError
 from core.config.settings import settings
 
 logger = logging.getLogger(__name__)
 
 
 async def get_device_token(device_id: str, platform: str) -> str:
+    """Запрашивает токен устройства у quasar.yandex.net.
+
+    Args:
+        device_id (str): Идентификатор станции.
+        platform (str): Платформа станции.
+    Returns:
+        str: Токен устройства.
+    Raises:
+        TokenRequestError: Если сервис вернул ошибку или ответ без токена.
+    """
     url = "https://quasar.yandex.net/glagol/token"
     params = {"device_id": device_id, "platform": platform}
 
@@ -17,24 +28,15 @@ async def get_device_token(device_id: str, platform: str) -> str:
     }
 
     async with aiohttp.ClientSession() as session:
+        async with session.get(
+            url, headers=headers, params=params
+        ) as response:
+            response_data = await response.json()
 
-        try:
-            async with session.get(
-                url, headers=headers, params=params
-            ) as response:
-                response_data = await response.json()
-                if (
-                    response_data.get("status") == "ok"
-                    and "token" in response_data
-                ):
-                    token = response_data["token"]
-                    logger.info("✅ Токен успешно получен")
-                    return token
-                else:
-                    logger.error(
-                        f"❌ Ошибка получения токена: {response_data}"
-                    )
-                    return None
-        except Exception as e:
-            logger.error(f"❌ Ошибка получения токена: {e}")
-            return None
+    if response_data.get("status") == "ok" and "token" in response_data:
+        logger.info("✅ Токен успешно получен")
+        return str(response_data["token"])
+
+    raise TokenRequestError(
+        f"Ошибка получения токена устройства {device_id}: {response_data}"
+    )

--- a/src/core/dependencies/main_di_container.py
+++ b/src/core/dependencies/main_di_container.py
@@ -1,3 +1,5 @@
+from typing import Optional, Sequence
+
 from injector import Injector, Module
 
 from core.dependencies.di_modules import (
@@ -10,14 +12,16 @@ from core.dependencies.di_modules import (
     YandexStationControlsModule,
 )
 
+ModuleSpec = type[Module] | Module
+
 
 class MainDIContainer:
     """Контейнер со всеми зависимостями (Singleton)."""
 
-    _instance = None
-    _container: Injector = None  # DI-контейнер
+    _instance: Optional["MainDIContainer"] = None
+    _container: Injector | None = None  # DI-контейнер
 
-    BASE_MODULES = [
+    BASE_MODULES: list[ModuleSpec] = [
         YandexStationClientModule,
         YandexStationControlsModule,
         RuarkR5ControllerModule,
@@ -27,22 +31,28 @@ class MainDIContainer:
         DeviceFinderModule,
     ]
 
-    def __new__(cls, additional_modules: list[Module] = None):
+    def __new__(
+        cls, additional_modules: Sequence[ModuleSpec] | None = None
+    ) -> "MainDIContainer":
         """Гарантирует, что контейнер создаётся один раз."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
 
             # Объединяем базовые и дополнительные модули
-            modules = cls.BASE_MODULES.copy()
+            modules = list(cls.BASE_MODULES)
             if additional_modules:
                 modules.extend(additional_modules)
 
-            cls._instance._container = Injector(
-                modules
-            )  # ✅ Создаём контейнер
+            cls._instance._container = Injector(modules)
 
         return cls._instance
 
     def get_container(self) -> Injector:
-        """Возвращает общий DI-контейнер."""
+        """Возвращает общий DI-контейнер.
+
+        Raises:
+            RuntimeError: Если контейнер не был создан.
+        """
+        if self._container is None:
+            raise RuntimeError("DI-контейнер не инициализирован")
         return self._container

--- a/src/dlna_stream_server/endpoints/stream.py
+++ b/src/dlna_stream_server/endpoints/stream.py
@@ -12,7 +12,7 @@ logger = getLogger(__name__)
 router = APIRouter()
 
 # Словарь для отслеживания активных задач
-_active_tasks = {}
+_active_tasks: dict[str, asyncio.Task[None]] = {}
 
 
 def _get_stream_handler(request: Request) -> StreamHandler:

--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -29,10 +29,10 @@ class StreamHandler:
         self._current_url: str | None = None
         self._current_radio: bool = False
         self._current_ffmpeg_params: list[str] | None = None
-        self._monitor_task: asyncio.Task | None = None
+        self._monitor_task: asyncio.Task[None] | None = None
         self._restart_attempts = 0
         self._max_restart_attempts = 3
-        self._restart_task: asyncio.Task | None = None
+        self._restart_task: asyncio.Task[None] | None = None
         self._is_restarting = False
 
     async def execute_with_lock(self, func, *args, **kwargs):
@@ -119,9 +119,12 @@ class StreamHandler:
 
         Строки фильтруются по уровням важности.
         """
+        stderr = proc.stderr
+        if stderr is None:
+            return
         try:
             while True:
-                line = await proc.stderr.readline()
+                line = await stderr.readline()
                 if not line:
                     break
                 line_str = line.decode("utf-8", errors="ignore").strip()
@@ -207,7 +210,7 @@ class StreamHandler:
             )
             await asyncio.sleep(delay)
 
-            if self._current_radio:
+            if self._current_radio and self._radio_url:
                 # При перезапуске передаем исходный мастер-плейлист
                 logger.info("🚀 Используем быструю логику для рестарта радио")
                 await self.start_ffmpeg_stream(
@@ -413,8 +416,9 @@ class StreamHandler:
         или не даёт данных — поток закрывается.
         """
         proc = self._ffmpeg_process
-        if not proc:
+        if not proc or proc.stdout is None:
             raise HTTPException(status_code=404, detail="Поток не запущен")
+        stdout = proc.stdout
 
         async def generate():
             try:
@@ -424,7 +428,7 @@ class StreamHandler:
                 total_bytes_sent = 0
                 while True:
                     # Выход после полной передачи stdout
-                    if proc.stdout.at_eof():
+                    if stdout.at_eof():
                         logger.info(
                             "📭 FFmpeg stdout закрылся (EOF) — поток завершён"
                         )
@@ -432,7 +436,7 @@ class StreamHandler:
 
                     try:
                         chunk = await asyncio.wait_for(
-                            proc.stdout.read(4096),
+                            stdout.read(4096),
                             timeout=15,  # Увеличили с 5 до 15 секунд
                         )
                     except asyncio.TimeoutError:

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -30,7 +30,7 @@ class MainStreamManager:
     _stream_state_running: bool
     _stream_server_url: str
     _ruark_volume: int
-    _tasks: list[asyncio.Task]
+    _tasks: list[asyncio.Task[None]]
 
     @inject
     def __init__(
@@ -114,7 +114,7 @@ class MainStreamManager:
                 playing=False,
             )
             stuck_track_count = 0
-            last_track_progress = 0
+            last_track_progress = 0.0
             volume_set_count = 0
             speak_count = 0
             track_url: str | None = None
@@ -175,16 +175,26 @@ class MainStreamManager:
                         and not await self._ruark_controls.is_playing()
                     ):
                         logger.info("🔁 Возобновляем воспроизведение радио")
-                        await self._send_track_to_stream_server(
-                            track_url=await self._station_controls.get_radio_url(),
-                            radio=True,
+                        radio_url = (
+                            await self._station_controls.get_radio_url()
                         )
-                        await asyncio.sleep(1)
+                        if radio_url:
+                            await self._send_track_to_stream_server(
+                                track_url=radio_url,
+                                radio=True,
+                            )
+                            await asyncio.sleep(1)
+                        else:
+                            logger.warning(
+                                "⚠️ Не удалось получить URL радиостанции"
+                            )
 
                     if track.id == last_track.id:
-                        track = (
+                        refreshed_track = (
                             await self._station_controls.get_current_track()
                         )
+                        if refreshed_track is not None:
+                            track = refreshed_track
 
                     if last_track.id != track.id and track.playing:
                         if track.type == "FmRadio":
@@ -199,11 +209,17 @@ class MainStreamManager:
                                     quality=settings.stream_quality,
                                 )
                             )
-                        await self._send_track_to_stream_server(
-                            track_url,
-                            radio=True if track.type == "FmRadio" else False,
-                        )
-                        last_track = track
+                        if track_url:
+                            await self._send_track_to_stream_server(
+                                track_url,
+                                radio=track.type == "FmRadio",
+                            )
+                            last_track = track
+                        else:
+                            logger.warning(
+                                f"⚠️ Не удалось получить URL для трека "
+                                f"{track.id}, повторим на следующей итерации"
+                            )
 
                     if speak_count > 0 and track.playing:
                         logger.info("🔁 Возвращаем громкость Ruark")
@@ -245,7 +261,8 @@ class MainStreamManager:
 
                     if (
                         (
-                            current_volume > 0
+                            current_volume is not None
+                            and current_volume > 0
                             and track.duration - track.progress > 10
                             and track.type != "FmRadio"
                         )
@@ -344,7 +361,7 @@ class MainStreamManager:
                 return response
 
     async def _recover_stuck_track(
-        self, track: Track, last_progress: int
+        self, track: Track, last_progress: float
     ) -> bool:
         logger.warning(
             "⚠️ Track.playing=False при IDLE, но прогресс меняется — "
@@ -358,14 +375,20 @@ class MainStreamManager:
 
             updated_track = await self._station_controls.get_current_track()
             if (
-                updated_track.id == track.id
+                updated_track is not None
+                and updated_track.id == track.id
                 and updated_track.progress > last_progress
             ):
                 logger.info("✅ Трек успешно перезапущен")
                 return True
         return False
 
-    def _log_current_track(self, track: Track, state: str, last_state: str):
+    def _log_current_track(
+        self,
+        track: Track,
+        state: str | None,
+        last_state: str | None,
+    ):
         logger.info(
             f"🎵 Сейчас играет: {track.id} - {track.artist} - "
             f"{track.title} - {track.progress}/{track.duration}, "

--- a/src/main_stream_service/yandex_music_api.py
+++ b/src/main_stream_service/yandex_music_api.py
@@ -15,10 +15,19 @@ class YandexMusicAPI:
 
     async def get_file_info(
         self,
-        track_id: int,
-        quality: str = None,
-        codecs: str = None,
-    ):
+        track_id: str | int,
+        quality: str | None = None,
+        codecs: str | None = None,
+    ) -> str | None:
+        """Возвращает прямую ссылку на файл трека.
+
+        Args:
+            track_id (str | int): Идентификатор трека.
+            quality (str | None): Желаемый битрейт в kbps.
+            codecs (str | None): Фильтр по кодеку.
+        Returns:
+            str | None: Прямая ссылка или None, если трек недоступен.
+        """
         track = await self._client.tracks(track_id)
         if not track:
             return None
@@ -37,12 +46,12 @@ class YandexMusicAPI:
         ]
 
         if quality:
-            quality = int(quality)
-            logger.info(f"🔍 Ищем ссылку с качеством: {quality} kbps")
+            quality_kbps = int(quality)
+            logger.info(f"🔍 Ищем ссылку с качеством: {quality_kbps} kbps")
             for info in candidates:
-                if info.bitrate_in_kbps == quality:
+                if info.bitrate_in_kbps == quality_kbps:
                     logger.info(f"✅ Найдена: {info.direct_link}")
-                    return info.direct_link
+                    return str(info.direct_link)
 
         # Если не указано качество — возвращаем лучшее
         best = max(candidates, key=lambda x: x.bitrate_in_kbps, default=None)
@@ -51,6 +60,6 @@ class YandexMusicAPI:
                 f"✅ Лучшее качество: {best.bitrate_in_kbps} "
                 f"kbps — {best.direct_link}"
             )
-            return best.direct_link
+            return str(best.direct_link)
 
         return None

--- a/src/ruark_audio_system/exceptions.py
+++ b/src/ruark_audio_system/exceptions.py
@@ -2,3 +2,9 @@ class RuarkDeviceNotFoundError(Exception):
     """Исключение, если устройство Ruark не найдено в сети."""
 
     pass
+
+
+class RuarkApiError(Exception):
+    """Исключение при ошибке HTTP API (fsapi) устройства Ruark."""
+
+    pass

--- a/src/ruark_audio_system/ruark_r5_controller.py
+++ b/src/ruark_audio_system/ruark_r5_controller.py
@@ -9,7 +9,10 @@ import upnpclient
 
 from core.config.settings import settings
 from ruark_audio_system.constants import META_INFO
-from ruark_audio_system.exceptions import RuarkDeviceNotFoundError
+from ruark_audio_system.exceptions import (
+    RuarkApiError,
+    RuarkDeviceNotFoundError,
+)
 
 SESSION_ID_REGEX = re.compile(r"<sessionId>(.*?)</sessionId>")
 POWER_STATUS_REGEX = re.compile(r"<value><u8>(.*?)</u8></value>")
@@ -359,76 +362,96 @@ class RuarkR5Controller:
         )
         logger.info(f"🎛 Выбран пресет: {preset_name}")
 
+    def _require_ip(self) -> str:
+        """Возвращает IP устройства или бросает ошибку, если оно не найдено.
+
+        Raises:
+            RuarkDeviceNotFoundError: Если устройство ещё не найдено в сети.
+        """
+        if self.ip is None:
+            raise RuarkDeviceNotFoundError(
+                f"Устройство '{self.device_name}' не найдено в сети — "
+                f"IP неизвестен, вызовите connect()"
+            )
+        return self.ip
+
     async def get_session_id(self) -> str:
-        """Получение session_id."""
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"http://{self.ip}/fsapi/CREATE_SESSION/"
-                    f"?pin={settings.ruark_pin}"
-                ) as response:
-                    content = await response.text()
-                    self._session_id = SESSION_ID_REGEX.search(content).group(
-                        1
-                    )
-                    return self._session_id
-        except Exception as e:
-            logger.error(f"Ошибка при получении session_id: {e}")
-            return ""
+        """Получение session_id.
+
+        Raises:
+            RuarkApiError: Если ответ fsapi не содержит sessionId.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"http://{self._require_ip()}/fsapi/CREATE_SESSION/"
+                f"?pin={settings.ruark_pin}"
+            ) as response:
+                content = await response.text()
+
+        match = SESSION_ID_REGEX.search(content)
+        if not match:
+            raise RuarkApiError(
+                f"Ответ CREATE_SESSION без sessionId: {content[:200]}"
+            )
+        self._session_id = match.group(1)
+        return self._session_id
 
     async def get_power_status(self) -> str:
-        """Получение статуса питания."""
+        """Получение статуса питания ('1' — включено, '0' — выключено).
+
+        Raises:
+            RuarkApiError: Если ответ fsapi не содержит статус питания.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"http://{self._require_ip()}/fsapi/GET/"
+                f"netRemote.sys.power?pin={settings.ruark_pin}"
+                f"&sid={self._session_id}"
+            ) as response:
+                content = await response.text()
+
+        match = POWER_STATUS_REGEX.search(content)
+        if not match:
+            raise RuarkApiError(
+                f"Ответ netRemote.sys.power без статуса: {content[:200]}"
+            )
+        status = match.group(1)
+        logger.info(f"🔌 Статус питания: {status}")
+        return status
+
+    async def _set_power(self, value: int) -> bool:
+        """Переключает питание и проверяет итоговый статус."""
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    f"http://{self.ip}/fsapi/GET/"
+                    f"http://{self._require_ip()}/fsapi/SET/"
                     f"netRemote.sys.power?pin={settings.ruark_pin}"
-                    f"&sid={self._session_id}"
+                    f"&sid={self._session_id}&value={value}"
                 ) as response:
-                    content = await response.text()
-                    status = POWER_STATUS_REGEX.search(content).group(1)
-                    logger.info(f"🔌 Статус питания: {status}")
-                    return status
-        except Exception as e:
-            logger.error(f"Ошибка при получении статуса питания: {e}")
-            return ""
+                    if response.status != 200:
+                        return False
+            return await self.get_power_status() == str(value)
+        except (
+            aiohttp.ClientError,
+            RuarkApiError,
+            RuarkDeviceNotFoundError,
+        ) as e:
+            logger.error(f"Ошибка при переключении питания: {e}")
+            return False
 
-    async def turn_power_on(self) -> str:
+    async def turn_power_on(self) -> bool:
         """Включение питания."""
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"http://{self.ip}/fsapi/SET/"
-                    f"netRemote.sys.power?pin={settings.ruark_pin}"
-                    f"&sid={self._session_id}&value=1"
-                ) as response:
-                    if response.status == 200:
-                        status = await self.get_power_status()
-                        if status == "1":
-                            logger.info("🔌 Питание включено")
-                            return True
-        except Exception as e:
-            logger.error(f"Ошибка при включении питания: {e}")
-            return False
+        success = await self._set_power(1)
+        if success:
+            logger.info("🔌 Питание включено")
+        return success
 
-    async def turn_power_off(self) -> str:
+    async def turn_power_off(self) -> bool:
         """Выключение питания."""
-        try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
-                    f"http://{self.ip}/fsapi/SET/"
-                    f"netRemote.sys.power?pin={settings.ruark_pin}"
-                    f"&sid={self._session_id}&value=0"
-                ) as response:
-                    if response.status == 200:
-                        status = await self.get_power_status()
-                        if status == "0":
-                            logger.info("🔌 Питание выключено")
-                            return True
-
-        except Exception as e:
-            logger.error(f"Ошибка при выключении питания: {e}")
-            return False
+        success = await self._set_power(0)
+        if success:
+            logger.info("🔌 Питание выключено")
+        return success
 
     def generate_metadata_with_fake_duration(self, uri: str) -> str:
         """Генерация DIDL-Lite метаданных с длительностью 999999 часов."""

--- a/src/yandex_station/mdns_device_finder.py
+++ b/src/yandex_station/mdns_device_finder.py
@@ -1,6 +1,7 @@
 import ipaddress
 from logging import getLogger
 from time import monotonic, sleep
+from typing import TypedDict
 
 from zeroconf import (
     ServiceBrowser,
@@ -12,11 +13,20 @@ from zeroconf import (
 logger = getLogger(__name__)
 
 
+class StationDevice(TypedDict):
+    """Параметры найденной Яндекс Станции."""
+
+    device_id: str
+    platform: str
+    host: str
+    port: int
+
+
 class DeviceFinder(ServiceListener):
     """Класс для поиска устройств Yandex Station в сети."""
 
     def __init__(self):
-        self.device = {}
+        self.device: StationDevice | None = None
         self.zeroconf = Zeroconf()
         self.browser: ServiceBrowser | None = None
 
@@ -56,8 +66,14 @@ class DeviceFinder(ServiceListener):
         """Обработчик событий для устройств Yandex Station."""
         try:
             info = zeroconf.get_service_info(service_type, name)
+            if info is None or not info.addresses or info.port is None:
+                logger.warning(f"⚠️ Неполные данные mDNS-сервиса {name}")
+                return
+
             properties = {
-                a.decode(): v.decode() for a, v in info.properties.items()
+                a.decode(): v.decode()
+                for a, v in info.properties.items()
+                if v is not None
             }
             logger.info(f"Properties: {properties}")
 

--- a/src/yandex_station/protobuf_parser.py
+++ b/src/yandex_station/protobuf_parser.py
@@ -1,4 +1,8 @@
 import base64
+from typing import Mapping, Union
+
+ProtoValue = Union[int, bytes, dict[int, "ProtoValue"], list["ProtoValue"]]
+ProtoDict = dict[int, ProtoValue]
 
 
 class Protobuf:
@@ -35,14 +39,15 @@ class Protobuf:
         data, pos = self._read(raw, pos, length)
         return data, pos
 
-    def _read_dict(self, raw: bytes, pos: int = 0) -> dict:
+    def _read_dict(self, raw: bytes, pos: int = 0) -> ProtoDict:
         """Парсит protobuf данные в словарь."""
-        res = {}
+        res: ProtoDict = {}
         while pos < len(raw):
             b, pos = self._read_varint(raw, pos)
             typ = b & 0b111
             tag = b >> 3
 
+            v: ProtoValue
             if typ == 0:  # VARINT
                 v, pos = self._read_varint(raw, pos)
             elif typ == 1:  # I64
@@ -58,13 +63,14 @@ class Protobuf:
             else:
                 raise NotImplementedError
 
-            if tag in res:
-                if isinstance(res[tag], list):
-                    res[tag] += [v]
-                else:
-                    res[tag] = [res[tag], v]
-            else:
+            if tag not in res:
                 res[tag] = v
+            else:
+                existing = res[tag]
+                if isinstance(existing, list):
+                    existing.append(v)
+                else:
+                    res[tag] = [existing, v]
 
         return res
 
@@ -75,14 +81,14 @@ class Protobuf:
             i >>= 7
         b.append(i)
 
-    def loads(self, raw: str | bytes) -> dict:
+    def loads(self, raw: str | bytes) -> ProtoDict:
         """Разбирает protobuf данные в словарь."""
         if isinstance(raw, str):
             raw = base64.b64decode(raw)
         return self._read_dict(raw)
 
-    def dumps(self, data: dict) -> bytes:
-        """Сериализует словарь в protobuf данные."""
+    def dumps(self, data: Mapping[int, object]) -> bytes:
+        """Сериализует словарь со строковыми значениями в protobuf."""
         b = bytearray()
         for tag, value in data.items():
             assert isinstance(tag, int)

--- a/src/yandex_station/station_controls.py
+++ b/src/yandex_station/station_controls.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from logging import getLogger
+from typing import Any
 
 from injector import inject
 
@@ -61,29 +62,33 @@ class YandexStationControls:
         except Exception as e:
             logger.error(f"❌ Ошибка при отправке текстового сообщения: {e}")
 
-    async def get_current_state(self):
+    async def get_current_state(self) -> dict[str, Any] | None:
         """Получение текущего состояния станции."""
         try:
             state = await self._ws_client.get_latest_message()
-            # logger.info(f"🎵 Состояние станции: {state}")
             if state:
-                return state.get("state", {})
-            else:
-                return None
+                return dict(state.get("state", {}))
+            return None
         except Exception as e:
             logger.error(
                 f"❌ Ошибка при получении текущего состояния станции: {e}"
             )
+            return None
 
-    async def get_radio_url(self):
+    async def get_radio_url(self) -> str | None:
         """Получение URL радиостанции."""
         try:
             data = await self._ws_client.get_latest_message()
-            state = self._protobuf.loads(data["extra"]["appState"])
+            if not data:
+                return None
+            # Навигация по reverse-engineered структуре protobuf —
+            # технический шов, наружу уходит только str | None
+            state: Any = self._protobuf.loads(data["extra"]["appState"])
             metaw = json.loads(state[6][3][7])
-            item = self._protobuf.loads(metaw["scenario_meta"]["queue_item"])
-            url = item[7][1].decode()
-            return url
+            item: Any = self._protobuf.loads(
+                metaw["scenario_meta"]["queue_item"]
+            )
+            return str(item[7][1].decode())
 
         except Exception as e:
             logger.error(
@@ -92,58 +97,63 @@ class YandexStationControls:
             )
             return None
 
-    async def get_alice_state(self):
-        """Получение состояния Алиса."""
+    async def get_alice_state(self) -> str | None:
+        """Получение состояния Алисы (IDLE, LISTENING, SPEAKING...)."""
         try:
             state = await self._ws_client.get_latest_message()
-            if state:
-                return state.get("state", {}).get("aliceState", {})
+            if not state:
+                return None
+            alice_state = state.get("state", {}).get("aliceState")
+            return str(alice_state) if alice_state else None
         except Exception as e:
             logger.error(f"❌ Ошибка при получении состояния Алиса: {e}")
             return None
 
-    async def get_player_status(self) -> bool:
-        """Получение статуса плеера."""
+    async def get_player_status(self) -> dict[str, Any] | None:
+        """Получение состояния плеера с флагом playing."""
         try:
             state = await self.get_current_state()
-            play_status = state.get("playing", {})
-            player_state = state.get("playerState", {})
-            player_state["playing"] = play_status
+            if state is None:
+                return None
+            player_state = dict(state.get("playerState", {}))
+            player_state["playing"] = state.get("playing", False)
             return player_state
         except Exception as e:
             logger.error(f"❌ Ошибка при получении статуса плеера: {e}")
-            return False
+            return None
 
     async def get_current_track(self) -> Track | None:
         """Получение текущего трека."""
         try:
             player_state = await self.get_player_status()
-            # logger.info(f"🎵 Состояние плеера: {player_state}") # TODO: remove
-            if player_state:
-                return Track(
-                    id=player_state.get("id", 0),
-                    title=player_state.get("title", ""),
-                    type=player_state.get("type", ""),
-                    artist=player_state.get("subtitle", ""),
-                    duration=player_state.get("duration", 0),
-                    progress=player_state.get("progress", 0),
-                    playing=player_state.get("playing", False),
-                )
-            else:
+            if not player_state:
                 return None
+            return Track(
+                id=str(player_state.get("id", "0")),
+                title=str(player_state.get("title", "")),
+                type=str(player_state.get("type", "")),
+                artist=str(player_state.get("subtitle", "")),
+                duration=float(player_state.get("duration") or 0),
+                progress=float(player_state.get("progress") or 0),
+                playing=bool(player_state.get("playing", False)),
+            )
         except Exception as e:
             logger.error(f"❌ Ошибка при получении текущего трека: {e}")
+            return None
 
-    async def get_volume(self):
-        """Получение текущего уровня громкости."""
+    async def get_volume(self) -> float | None:
+        """Получение текущего уровня громкости (0.0–1.0)."""
         try:
             state = await self._ws_client.get_latest_message()
-            if state:
-                logger.info(
-                    f"🔊 Получение текущего уровня громкости Алиcы: "
-                    f"{state.get('state', {}).get('volume', {})}"
-                )
-                return state.get("state", {}).get("volume", {})
+            if not state:
+                return None
+            volume = state.get("state", {}).get("volume")
+            if volume is None:
+                return None
+            logger.info(
+                f"🔊 Получение текущего уровня громкости Алиcы: {volume}"
+            )
+            return float(volume)
         except Exception as e:
             logger.error(f"❌ Ошибка при получении громкости: {e}")
             return None
@@ -151,13 +161,10 @@ class YandexStationControls:
     async def set_default_volume(self):
         """Установка громкости по умолчанию."""
         logger.info("🔊 Установка громкости по умолчанию")
-        try:
-            self._volume = await self.get_volume()
-            logger.info(f"Громкость по умолчанию: {self._volume}")
-        except Exception as e:
-            logger.error(
-                f"❌ Ошибка при установке громкости по умолчанию: {e}"
-            )
+        volume = await self.get_volume()
+        if volume is not None:
+            self._volume = volume
+        logger.info(f"Громкость по умолчанию: {self._volume}")
 
     async def set_volume(self, volume: float):
         """Установка уровня громкости."""
@@ -182,7 +189,9 @@ class YandexStationControls:
         state = await self.get_alice_state()
 
         if state not in ALICE_ACTIVE_STATES:
-            self._volume = await self.get_volume()
+            volume = await self.get_volume()
+            if volume is not None:
+                self._volume = volume
             await self._ws_client.send_command(
                 {"command": "setVolume", "volume": 0}
             )
@@ -220,8 +229,13 @@ class YandexStationControls:
             return
         logger.info(f"🎧 Ждём {FADE_TIME}s перед fade out громкости")
         await asyncio.sleep(FADE_TIME)
-        self._volume = await self.get_volume()
-        start_volume = self._volume
+        start_volume = await self.get_volume()
+        if start_volume is None:
+            logger.warning(
+                "⚠️ Громкость станции неизвестна, fade out пропущен"
+            )
+            return
+        self._volume = start_volume
         volume = round(start_volume - (start_volume % step), 1)
 
         logger.info(

--- a/src/yandex_station/station_ws_control.py
+++ b/src/yandex_station/station_ws_control.py
@@ -6,7 +6,7 @@ import ssl
 import time
 import uuid
 from collections import deque
-from typing import Dict, Tuple
+from typing import Any
 
 import aiohttp
 from injector import inject
@@ -29,28 +29,46 @@ class YandexStationClient:
     def __init__(
         self,
         device_finder: DeviceFinder,
-        device_token: str = None,
+        device_token: str | None = None,
         buffer_size: int = 10,
     ):
         self.device_finder = device_finder
         self.device_token = device_token
-        self.queue = deque(maxlen=buffer_size)  # Очередь для сообщений станции
-        self.waiters: Dict[str, Tuple[asyncio.Future, float]] = {}
+        # Очередь для сообщений станции
+        self.queue: deque[dict[str, Any]] = deque(maxlen=buffer_size)
+        self.waiters: dict[
+            str, tuple[asyncio.Future[dict[str, Any]], float]
+        ] = {}
         self.lock = asyncio.Lock()
-        self.session: aiohttp.ClientSession = None
-        self.websocket: aiohttp.ClientWebSocketResponse = None
-        self.command_queue = asyncio.Queue()
+        self.session: aiohttp.ClientSession | None = None
+        self.websocket: aiohttp.ClientWebSocketResponse | None = None
+        self.command_queue: asyncio.Queue[dict[str, Any] | str] = (
+            asyncio.Queue()
+        )
         self.authenticated = False
         self.running = True
         self.reconnect_required = False
-        self._connect_task: asyncio.Task | None = None
-        self._connected_at = None
-        self.tasks = []  # Хранение фоновых задач
+        self._connect_task: asyncio.Task[None] | None = None
+        self._connected_at: float | None = None
+        # Хранение фоновых задач
+        self.tasks: list[asyncio.Task[None]] = []
 
         # Параметры станции заполняются в _ensure_device при запуске
         self.device_id: str | None = None
         self.platform: str | None = None
         self.uri: str | None = None
+
+    def _require_station_params(self) -> tuple[str, str, str]:
+        """Возвращает device_id, platform и uri найденной станции.
+
+        Raises:
+            StationNotFoundError: Если параметры ещё не заполнены.
+        """
+        if self.device_id is None or self.platform is None or self.uri is None:
+            raise StationNotFoundError(
+                "Параметры станции не заполнены — вызовите run_once()"
+            )
+        return self.device_id, self.platform, self.uri
 
     async def _ensure_device(self) -> None:
         """Находит станцию в сети, если она ещё не найдена.
@@ -62,14 +80,14 @@ class YandexStationClient:
             return
 
         logger.info("🔍 Поиск Яндекс Станции в сети...")
-        found = await asyncio.to_thread(self.device_finder.find_devices)
-        if not found:
+        await asyncio.to_thread(self.device_finder.find_devices)
+        device = self.device_finder.device
+        if not device:
             raise StationNotFoundError(
                 "Яндекс Станция не найдена в сети "
                 "(mDNS-сервис _yandexio._tcp.local.)"
             )
 
-        device = self.device_finder.device
         self.device_id = device["device_id"]
         self.platform = device["platform"]
         self.uri = f"wss://{device['host']}:{device['port']}"
@@ -88,6 +106,8 @@ class YandexStationClient:
 
     async def connect(self):
         """Подключение к WebSocket станции."""
+        device_id, platform, uri = self._require_station_params()
+
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
@@ -103,7 +123,7 @@ class YandexStationClient:
                 try:
                     if not self.device_token:
                         self.device_token = await get_device_token(
-                            self.device_id, self.platform
+                            device_id, platform
                         )
 
                     if (
@@ -127,9 +147,9 @@ class YandexStationClient:
 
                     async with aiohttp.ClientSession() as session:
                         self.session = session
-                        logger.info(f"🔄 Подключение к станции: {self.uri}")
+                        logger.info(f"🔄 Подключение к станции: {uri}")
                         self.websocket = await session.ws_connect(
-                            self.uri,
+                            uri,
                             ssl=ssl_context,
                             timeout=aiohttp.ClientWSTimeout(ws_close=10),
                         )
@@ -228,8 +248,9 @@ class YandexStationClient:
             while self.running:
                 await asyncio.sleep(30)
 
+                # running переключает другая задача, mypy этого не видит
                 if not self.running:
-                    logger.debug(
+                    logger.debug(  # type: ignore[unreachable]
                         "🛑 Клиент остановлен — выходим из "
                         "keep_alive_ws_connection"
                     )
@@ -289,7 +310,7 @@ class YandexStationClient:
 
             if response.get("requestId"):
                 request_id = response.get("requestId")
-                software_version = response.get("softwareVersion")
+                software_version = str(response.get("softwareVersion", ""))
                 logger.info(
                     f"🔑 Авторизация успешна: {request_id}\n"
                     f"🔖 Версия ПО: {software_version}"
@@ -315,10 +336,8 @@ class YandexStationClient:
     async def refresh_token(self):
         """Запрашивает новый токен и перезапускает WebSocket."""
         logger.info("🔄 Запрос нового токена...")
-        # Здесь вызываем функцию обновления токена
-        self.device_token = await get_device_token(
-            self.device_id, self.platform
-        )
+        device_id, platform, _ = self._require_station_params()
+        self.device_token = await get_device_token(device_id, platform)
         logger.info("✅ Новый токен получен. Переподключение...")
         await asyncio.sleep(1)
 
@@ -326,8 +345,13 @@ class YandexStationClient:
         """Постоянный поток сообщений от станции с защитой от зависания."""
         logger.info("📥 Поток приёма сообщений от станции запущен")
 
+        websocket = self.websocket
+        if websocket is None:
+            logger.warning("❌ WebSocket не инициализирован")
+            return
+
         while self.running:
-            if self.websocket.closed:
+            if websocket.closed:
                 logger.warning("❌ WebSocket внезапно закрыт")
                 self.reconnect_required = True
                 self.running = False
@@ -335,9 +359,7 @@ class YandexStationClient:
 
             try:
                 # Ждём сообщение от станции, не дольше 30 секунд
-                msg = await asyncio.wait_for(
-                    self.websocket.receive(), timeout=30
-                )
+                msg = await asyncio.wait_for(websocket.receive(), timeout=30)
 
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     data = json.loads(msg.data)
@@ -444,7 +466,7 @@ class YandexStationClient:
                     logger.error(f"❌ Ошибка при отправке команды: {e}")
         logger.info("🛑 command_producer_handler завершен")
 
-    async def send_command(self, command: dict) -> dict:
+    async def send_command(self, command: dict[str, Any]) -> dict[str, Any]:
         """Отправляет команду в очередь на станцию.
 
         Ожидает именованный uuid ответ от станции на команду.
@@ -612,7 +634,11 @@ class YandexStationClient:
 
     def _check_duplicate_tasks(self):
         """Проверка на повторяющиеся задачи."""
-        names = [t.get_coro().__name__ for t in self.tasks if not t.done()]
+        names = [
+            getattr(t.get_coro(), "__name__", "unknown")
+            for t in self.tasks
+            if not t.done()
+        ]
         duplicates = {n for n in names if names.count(n) > 1}
         if duplicates:
             logger.warning(f"⚠️ Найдены повторяющиеся задачи: {duplicates}")


### PR DESCRIPTION
## Что сделано

Этап 4 рефакторинга: mypy работает без послаблений, ошибки перестали превращаться в None/пустые строки. Проверено на живой системе.

### Типизация
- убраны все коды из `disable_error_code` (72+ скрытых замечания разобраны), включены `check_untyped_defs` и `disallow_any_generics`, подключён плагин `pydantic.mypy` — 0 ошибок в 36 файлах
- protobuf-парсер типизирован рекурсивным алиасом `ProtoValue`/`ProtoDict` без Any
- устройство станции — `TypedDict StationDevice`, параметры станции централизованы в `_require_station_params()`
- методы `station_controls` получили честные типы возвратов: `float | None` вместо `{}` у `get_volume` (сравнение `{} > 0` роняло цикл стриминга с TypeError), `dict | None` вместо `-> bool` у `get_player_status`
- параметризованы `asyncio.Task`/`Future`/`Queue`/`deque`, убраны устаревшие `Dict`/`Tuple` и неявные Optional

### Контракт ошибок
- `get_device_token` бросает `TokenRequestError` вместо None — команды больше не уходят на станцию с `conversationToken: None`
- `get_session_id`/`get_power_status` Ruark бросают `RuarkApiError` вместо пустой строки; `turn_power_on/off` возвращают `bool` (была аннотация `-> str` при возврате `True/None`)
- в `streaming()` трек без полученного URL пропускается с повтором, а не отправляется на стрим-сервер как None