### PR TITLE
ci: пайплайн CI/CD с деплоем на Raspberry Pi

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,84 @@
+# CI/CD: проверки на GitHub-hosted раннерах, деплой — на self-hosted
+# раннере Raspberry Pi. Деплой срабатывает только на push в main,
+# поэтому код из форков на Raspberry никогда не выполняется.
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ci:
+    name: Линтеры, типы и тесты
+    runs-on: ubuntu-latest
+    env:
+      # Фиктивные значения настроек: реальные нужны только в рантайме
+      APP_YA_MUSIC_TOKEN: ci-dummy-token
+      APP_LOCAL_SERVER_HOST: 127.0.0.1
+      APP_LOCAL_SERVER_PORT_DLNA: "8080"
+      APP_LOCAL_SERVER_PORT_API: "8001"
+      APP_RUARK_PIN: "1234"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Установка Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Установка зависимостей
+        run: pip install -r requirements-dev.txt
+
+      - name: Проверка форматирования (black)
+        run: black --check src tests
+
+      - name: Проверка импортов (isort)
+        run: isort --check-only src tests
+
+      - name: Линтер (flake8)
+        run: flake8 .
+
+      - name: Проверка типов (mypy)
+        run: mypy
+
+      - name: Тесты (pytest)
+        run: pytest -q
+
+  deploy:
+    name: Деплой на Raspberry Pi
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, raspberry]
+    concurrency:
+      group: deploy-raspberry
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Подготовка .env
+        run: cp "$HOME/.config/ya2dlna/.env" .env
+
+      - name: Сборка образов
+        run: docker compose build
+
+      - name: Перезапуск сервисов
+        run: docker compose up -d
+
+      - name: Проверка живости сервисов
+        run: |
+          sleep 10
+          curl -sf -o /dev/null http://localhost:8001/docs
+          curl -sf -o /dev/null http://localhost:8080/docs
+          echo "✅ Оба сервиса отвечают"
+
+      - name: Чистка неиспользуемых образов
+        run: docker image prune -f

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <img src="https://img.shields.io/github/stars/0xcodepunk/ya2dlna_streaming?style=social" alt="GitHub Repo stars"/>
   <img src="https://img.shields.io/github/last-commit/0xcodepunk/ya2dlna_streaming?color=blue" alt="Last commit">
   <img src="https://img.shields.io/github/languages/top/0xcodepunk/ya2dlna_streaming" alt="Top language">
+  <img src="https://github.com/0xcodepunk/ya2dlna_streaming/actions/workflows/ci-cd.yml/badge.svg" alt="CI/CD">
 </p>
 
 Проект для стриминга контента с **Яндекс Станции** на **DLNA-совместимые устройства** и управления аудиосистемой **Ruark R5**.  


### PR DESCRIPTION
## Что сделано

Полный пайплайн: проверки на GitHub-hosted раннерах, деплой на self-hosted раннер Raspberry Pi.

### CI (ubuntu-latest, для всех PR и push в main)
black --check, isort --check-only, flake8, mypy, pytest — вся обвязка, собранная за время рефакторинга. Настройки приложения задаются фиктивными env-переменными, pip-кеш включён.

### CD (self-hosted раннер с меткой raspberry)
Срабатывает **только на push в main** после успешного CI: checkout → .env из ~/.config/ya2dlna/ → docker compose build → up -d → healthcheck обоих сервисов → prune образов. Одновременные деплои исключены concurrency-группой.

### Безопасность (репозиторий публичный)
Код из форков никогда не выполняется на Raspberry: деплой привязан к push в main, куда форки пушить не могут. CI для форков идёт на GitHub-hosted раннерах со стандартным механизмом одобрения.

Прогон CI на этом PR — живая проверка пайплайна. Мержить после установки раннера на Raspberry, иначе деплой повиснет в очереди.

🤖 Generated with [Claude Code](https://claude.com/claude-code)