### PR TITLE
chore: постоянная папка данных для логов и кеша

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,12 @@
-version: '3.8'
-
 services:
   api_service:
     build: .
     command: api
-    ports:
-      - "8001:8001"  
     volumes:
-      - ./logs:/app/logs
-      - ./cache:/app/cache
+      # YA2DLNA_DATA_DIR — постоянная папка для данных вне рабочей
+      # директории деплоя; без переменной — рядом с compose-файлом
+      - ${YA2DLNA_DATA_DIR:-.}/logs:/app/logs
+      - ${YA2DLNA_DATA_DIR:-.}/cache:/app/cache
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     env_file:
@@ -21,11 +19,9 @@ services:
   dlna_server:
     build: .
     command: dlna
-    ports:
-      - "8080:8080"
     volumes:
-      - ./logs:/app/logs
-      - ./cache:/app/cache
+      - ${YA2DLNA_DATA_DIR:-.}/logs:/app/logs
+      - ${YA2DLNA_DATA_DIR:-.}/cache:/app/cache
       - /etc/localtime:/etc/localtime:ro
       - /etc/timezone:/etc/timezone:ro
     env_file:


### PR DESCRIPTION
Рабочая папка раннера очищается git clean при каждом деплое, поэтому логи и кеш жили от релиза до релиза.

- bind-маунты `logs`/`cache` параметризованы `${YA2DLNA_DATA_DIR:-.}` — на Raspberry данные переезжают в `/root/ya2dlna-data`, для запуска по README без переменной ничего не меняется
- удалены секции `ports` (игнорируются при `network_mode: host`) и устаревший `version`

Перед мержем на Raspberry добавляется `YA2DLNA_DATA_DIR=/root/ya2dlna-data` в эталонный .env и переносятся существующие логи.

🤖 Generated with [Claude Code](https://claude.com/claude-code)