### PR TITLE
feat: тайминги этапов переключения трека

### DIFF
--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import time
 from logging import getLogger
 from typing import Any, Awaitable, Callable, Sequence
 
@@ -143,6 +144,8 @@ class StreamHandler:
                 # Счётчик таймаутов для снижения шума в логах
                 timeout_count = 0
                 total_bytes_sent = 0
+                serve_started = time.monotonic()
+                first_chunk_sent = False
                 while True:
                     # Выход после полной передачи stdout
                     if stdout.at_eof():
@@ -184,6 +187,13 @@ class StreamHandler:
                     empty_count = 0
                     # Сбрасываем счётчик при получении данных
                     timeout_count = 0
+                    if not first_chunk_sent:
+                        first_chunk_sent = True
+                        logger.info(
+                            f"⏱ Первый чанк клиенту через "
+                            f"{time.monotonic() - serve_started:.2f}с "
+                            f"после подключения"
+                        )
                     total_bytes_sent += len(chunk)
                     # Диагностика: логируем прогресс передачи данных
                     if total_bytes_sent % (1024 * 1024) == 0:  # Каждый МБ
@@ -249,14 +259,22 @@ class StreamHandler:
         self._ffmpeg.reset_restart_state()
 
         try:
+            play_started = time.monotonic()
             # Запускаем потоковую передачу (быстро, без ожидания)
             await self.start_ffmpeg_stream(yandex_url, radio, start_position)
+            ffmpeg_seconds = time.monotonic() - play_started
 
             track_url = self._local_stream_url(radio)
             logger.info(f"📡 Поток доступен по URL: {track_url}")
 
+            reattach_started = time.monotonic()
             await self._reattach_ruark(radio)
 
+            logger.info(
+                f"⏱ Запуск потока: FFmpeg {ffmpeg_seconds:.2f}с, "
+                f"привязка Ruark "
+                f"{time.monotonic() - reattach_started:.2f}с"
+            )
             logger.info("✅ Переключение трека завершено быстро!")
 
         except Exception as e:

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -299,6 +299,7 @@ class MainStreamManager:
             f"🔁 Ресинк стрима ({reason}): ожидали "
             f"~{expected_progress:.0f}s, станция на {track.progress:.0f}s"
         )
+        resync_started = time.monotonic()
         track_url = await self._yandex_music_api.get_file_info(
             track_id=track.id,
             quality=settings.stream_quality,
@@ -312,6 +313,10 @@ class MainStreamManager:
             track_url,
             radio=False,
             start_position=track.progress,
+        )
+        logger.info(
+            f"⏱ Ресинк выполнен за "
+            f"{time.monotonic() - resync_started:.2f}с"
         )
 
     async def _switch_to_new_track(

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -325,6 +325,7 @@ class MainStreamManager:
         if not (ctx.last_track.id != track.id and track.playing):
             return
 
+        switch_started = time.monotonic()
         if track.type == "FmRadio":
             ctx.track_url = await self._station_controls.get_radio_url()
             logger.info(f"🎵 URL радиостанции: {ctx.track_url}")
@@ -333,6 +334,7 @@ class MainStreamManager:
                 track_id=track.id,
                 quality=settings.stream_quality,
             )
+        resolve_seconds = time.monotonic() - switch_started
 
         if ctx.track_url:
             start_position = 0.0
@@ -345,10 +347,16 @@ class MainStreamManager:
                     f"▶️ Трек уже играет на станции, продолжаем "
                     f"с {start_position:.0f}s"
                 )
+            send_started = time.monotonic()
             await self._send_track_to_stream_server(
                 ctx.track_url,
                 radio=track.type == "FmRadio",
                 start_position=start_position,
+            )
+            logger.info(
+                f"⏱ Переключение на {track.id}: ссылка "
+                f"{resolve_seconds:.2f}с, отправка "
+                f"{time.monotonic() - send_started:.2f}с"
             )
             ctx.last_track = track
         else:


### PR DESCRIPTION
Инструментация перед оптимизацией реактивности: в логи добавлены длительности каждого этапа цепочки переключения.

- менеджер: «⏱ Переключение на <id>: ссылка X.XXс, отправка Y.YYс», «⏱ Ресинк выполнен за Z.ZZс»
- стрим-сервер: «⏱ Запуск потока: FFmpeg X.XXс, привязка Ruark Y.YYс», «⏱ Первый чанк клиенту через Z.ZZс»

После пары переключений и ресинков в логах будет полная картина, где теряется время (гипотеза: привязка Ruark по UPnP — главный кандидат). Оптимизация — следующим PR по этим данным.

Поведение не меняется, только логи. 60 тестов, mypy strict, flake8 — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)