### PR TITLE
feat: реальные метаданные трека на дисплее Ruark

### DIFF
--- a/src/dlna_stream_server/endpoints/stream.py
+++ b/src/dlna_stream_server/endpoints/stream.py
@@ -26,10 +26,14 @@ async def _handle_stream_task(
     task_id: str,
     radio: bool = False,
     start_position: float = 0.0,
+    title: str = "",
+    artist: str = "",
 ):
     """Обработчик задачи потока с логированием ошибок."""
     try:
-        await stream_handler.play_stream(yandex_url, radio, start_position)
+        await stream_handler.play_stream(
+            yandex_url, radio, start_position, title, artist
+        )
         logger.info(f"✅ Задача потока {task_id} завершена успешно")
     except Exception as e:
         logger.exception(f"❌ Ошибка в задаче потока {task_id}: {e}")
@@ -44,11 +48,14 @@ async def set_stream(
     yandex_url: str,
     radio: bool = False,
     start_position: float = 0.0,
+    title: str = "",
+    artist: str = "",
 ):
     """Принимает URL трека и запускает потоковую передачу на Ruark.
 
-    start_position — позиция старта в секундах для ресинка
-    (повтор, перемотка, продолжение после паузы).
+    start_position — позиция старта в секундах для ресинка (повтор,
+    перемотка, продолжение после паузы); title и artist показываются
+    на дисплее Ruark.
     """
     logger.info(
         f"📥 Запуск нового потока с {yandex_url} "
@@ -73,6 +80,8 @@ async def set_stream(
             task_id,
             radio,
             start_position,
+            title,
+            artist,
         )
     )
     _active_tasks[task_id] = task

--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 
 from core.config.settings import settings
+from ruark_audio_system.constants import DEFAULT_STREAM_TITLE
 from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 
 from .constants import (
@@ -44,6 +45,8 @@ class StreamHandler:
         self._ruark_controls = ruark_controls
         self._ruark_lock = asyncio.Lock()
         self._ffmpeg = FfmpegSupervisor(on_restarted=self._reattach_ruark)
+        # Метаданные текущего потока для дисплея Ruark: (title, artist)
+        self._now_playing: tuple[str, str] = (DEFAULT_STREAM_TITLE, "")
 
     async def execute_with_lock(
         self,
@@ -80,8 +83,12 @@ class StreamHandler:
     async def _reattach_ruark(self, radio: bool) -> None:
         """Заново привязывает Ruark к локальному стриму и запускает play."""
         track_url = self._local_stream_url(radio)
+        title, artist = self._now_playing
         await self.execute_with_lock(
-            self._ruark_controls.set_av_transport_uri, track_url
+            self._ruark_controls.set_av_transport_uri,
+            track_url,
+            title=title,
+            artist=artist,
         )
         await self.execute_with_lock(self._ruark_controls.play)
 
@@ -251,8 +258,11 @@ class StreamHandler:
         yandex_url: str,
         radio: bool = False,
         start_position: float = 0.0,
+        title: str = "",
+        artist: str = "",
     ) -> None:
         """Запускает потоковую трансляцию и передает её на Ruark."""
+        self._now_playing = (title or DEFAULT_STREAM_TITLE, artist)
         logger.info(f"🎶 Начинаем потоковое воспроизведение {yandex_url}")
 
         # Сбрасываем счетчик попыток и флаги для нового потока

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -254,6 +254,7 @@ class MainStreamManager:
             await self._send_track_to_stream_server(
                 track_url=radio_url,
                 radio=True,
+                title=track.title,
             )
             await asyncio.sleep(1)
         else:
@@ -313,6 +314,8 @@ class MainStreamManager:
             track_url,
             radio=False,
             start_position=track.progress,
+            title=track.title,
+            artist=track.artist,
         )
         logger.info(
             f"⏱ Ресинк выполнен за "
@@ -357,6 +360,8 @@ class MainStreamManager:
                 ctx.track_url,
                 radio=track.type == "FmRadio",
                 start_position=start_position,
+                title=track.title,
+                artist=track.artist,
             )
             logger.info(
                 f"⏱ Переключение на {track.id}: ссылка "
@@ -399,6 +404,8 @@ class MainStreamManager:
                         start_position=(
                             track.progress if track.type != "FmRadio" else 0.0
                         ),
+                        title=track.title,
+                        artist=track.artist,
                     )
                 else:
                     logger.warning(
@@ -495,6 +502,8 @@ class MainStreamManager:
         track_url: str,
         radio: bool = False,
         start_position: float = 0.0,
+        title: str = "",
+        artist: str = "",
     ):
         """Отправляет ссылку на трек на стрим сервер.
 
@@ -502,6 +511,8 @@ class MainStreamManager:
             track_url (str): Прямая ссылка на источник потока.
             radio (bool): Режим радио.
             start_position (float): Позиция старта в секундах.
+            title (str): Название трека для дисплея Ruark.
+            artist (str): Исполнитель для дисплея Ruark.
         """
         try:
             async with aiohttp.ClientSession() as session:
@@ -513,6 +524,8 @@ class MainStreamManager:
                         "yandex_url": track_url,
                         "radio": str(radio).lower(),
                         "start_position": f"{start_position:.1f}",
+                        "title": title,
+                        "artist": artist,
                     },
                 ) as resp:
                     response = await resp.json()

--- a/src/ruark_audio_system/constants.py
+++ b/src/ruark_audio_system/constants.py
@@ -3,13 +3,18 @@ META_INFO = """<?xml version="1.0" encoding="utf-8"?>
            xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
            xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
   <item id="0" parentID="-1" restricted="false">
-    <dc:title>Internet Radio</dc:title>
+    <dc:title>{title}</dc:title>
+    <dc:creator>{artist}</dc:creator>
+    <upnp:artist>{artist}</upnp:artist>
     <res protocolInfo="http-get:*:audio/mpeg:*"
          duration="24:00:00.000">{url}</res>
     <upnp:class>object.item.audioItem.audioBroadcast</upnp:class>
-    <upnp:radioCallSign>DLNA Radio</upnp:radioCallSign>
+    <upnp:radioCallSign>Yandex Music</upnp:radioCallSign>
     <upnp:radioStationID>123456</upnp:radioStationID>
     <upnp:radioBand>Internet</upnp:radioBand>
     <upnp:channelNr>1</upnp:channelNr>
   </item>
 </DIDL-Lite>"""
+
+# Заголовок потока по умолчанию, когда метаданные трека неизвестны
+DEFAULT_STREAM_TITLE = "Internet Radio"

--- a/src/ruark_audio_system/ruark_r5_controller.py
+++ b/src/ruark_audio_system/ruark_r5_controller.py
@@ -2,11 +2,12 @@ import asyncio
 import urllib.parse
 from logging import getLogger
 from typing import Any, Dict, List, Literal, Optional
+from xml.sax.saxutils import escape
 
 import upnpclient
 
 from core.config.settings import settings
-from ruark_audio_system.constants import META_INFO
+from ruark_audio_system.constants import DEFAULT_STREAM_TITLE, META_INFO
 from ruark_audio_system.exceptions import RuarkDeviceNotFoundError
 from ruark_audio_system.fsapi_client import RuarkFsApiClient
 
@@ -190,9 +191,16 @@ class RuarkR5Controller:
         )
 
     #   AVTransport
-    async def set_av_transport_uri(self, uri: str) -> None:
-        """Установка нового потока."""
-        metadata = self.generate_metadata_with_fake_duration(uri)
+    async def set_av_transport_uri(
+        self,
+        uri: str,
+        title: str = DEFAULT_STREAM_TITLE,
+        artist: str = "",
+    ) -> None:
+        """Установка нового потока с метаданными для дисплея."""
+        metadata = self.generate_metadata_with_fake_duration(
+            uri, title=title, artist=artist
+        )
         await asyncio.to_thread(
             self.av_transport.SetAVTransportURI,
             InstanceID=0,
@@ -383,10 +391,24 @@ class RuarkR5Controller:
         """Выключение питания."""
         return await self._fsapi.turn_power_off()
 
-    def generate_metadata_with_fake_duration(self, uri: str) -> str:
-        """Генерация DIDL-Lite метаданных с длительностью 999999 часов."""
-        logger.info(f"🔊 Генерируем метаданные для {uri}")
-        return META_INFO.format(url=uri)
+    def generate_metadata_with_fake_duration(
+        self,
+        uri: str,
+        title: str = DEFAULT_STREAM_TITLE,
+        artist: str = "",
+    ) -> str:
+        """Генерация DIDL-Lite метаданных с длительностью 24 часа.
+
+        Название и исполнитель показываются на дисплее устройства,
+        спецсимволы XML экранируются.
+        """
+        display_title = f"{artist} — {title}" if artist else title
+        logger.info(f"🔊 Метаданные потока: {display_title}")
+        return META_INFO.format(
+            url=escape(uri),
+            title=escape(display_title),
+            artist=escape(artist),
+        )
 
     async def print_status(self) -> None:
         """Вывод текущего состояния устройства."""

--- a/tests/test_ruark_metadata.py
+++ b/tests/test_ruark_metadata.py
@@ -1,0 +1,48 @@
+from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
+
+
+def test_metadata_contains_artist_and_title():
+    controller = RuarkR5Controller()
+
+    metadata = controller.generate_metadata_with_fake_duration(
+        "http://host/live_stream.mp3",
+        title="Песня",
+        artist="Артист",
+    )
+
+    assert "<dc:title>Артист — Песня</dc:title>" in metadata
+    assert "<upnp:artist>Артист</upnp:artist>" in metadata
+
+
+def test_metadata_escapes_xml_special_characters():
+    controller = RuarkR5Controller()
+
+    metadata = controller.generate_metadata_with_fake_duration(
+        "http://host/live_stream.mp3",
+        title="R&B <Mix>",
+        artist="A&B",
+    )
+
+    assert "A&amp;B — R&amp;B &lt;Mix&gt;" in metadata
+    assert "<Mix>" not in metadata
+
+
+def test_metadata_without_artist_uses_plain_title():
+    controller = RuarkR5Controller()
+
+    metadata = controller.generate_metadata_with_fake_duration(
+        "http://host/live_stream.mp3",
+        title="Радио Jazz",
+    )
+
+    assert "<dc:title>Радио Jazz</dc:title>" in metadata
+
+
+def test_metadata_defaults_to_internet_radio():
+    controller = RuarkR5Controller()
+
+    metadata = controller.generate_metadata_with_fake_duration(
+        "http://host/live_stream.mp3"
+    )
+
+    assert "<dc:title>Internet Radio</dc:title>" in metadata

--- a/tests/test_stream_handler.py
+++ b/tests/test_stream_handler.py
@@ -152,3 +152,17 @@ def test_insert_start_position_zero_keeps_params_unchanged():
     assert _insert_start_position(FFMPEG_MP3_PARAMS, 0.0) == list(
         FFMPEG_MP3_PARAMS
     )
+
+
+async def test_play_stream_passes_metadata_to_ruark():
+    handler, ruark = make_handler()
+    set_params(handler, ["sleep", "30"])
+
+    await handler.play_stream(
+        "http://example/track", title="Песня", artist="Артист"
+    )
+
+    call = ruark.set_av_transport_uri.call_args
+    assert call.kwargs["title"] == "Песня"
+    assert call.kwargs["artist"] == "Артист"
+    await handler.stop_ffmpeg()

--- a/tests/test_streaming_loop.py
+++ b/tests/test_streaming_loop.py
@@ -135,6 +135,9 @@ async def test_new_track_sent_to_stream_server(fast_sleep):
     assert send_call.kwargs["radio"] is False
     # Свежий трек (прогресс ниже порога) стартует с начала
     assert send_call.kwargs["start_position"] == pytest.approx(0.0)
+    # Метаданные трека уезжают на стрим сервер для дисплея Ruark
+    assert send_call.kwargs["title"] == "title"
+    assert send_call.kwargs["artist"] == "artist"
 
 
 async def test_radio_track_sent_with_radio_flag(fast_sleep):


### PR DESCRIPTION
## Что сделано

На дисплее Ruark вместо вечного «Internet Radio» теперь исполнитель и название текущего трека (для радио — название станции).

- DIDL-Lite шаблон параметризован: `dc:title` = «Исполнитель — Название», плюс `dc:creator`/`upnp:artist`; спецсимволы XML экранируются (треки вида «R&B <Mix>» не ломают привязку)
- метаданные едут по цепочке Track → `/set_stream` → `play_stream` → SetAVTransportURI; привязка происходит на каждый трек, так что дисплей обновляется при каждом переключении
- `StreamHandler` помнит «сейчас играет» и использует при автоперезапусках потока