### PR TITLE
fix: один активный слушатель потока

### DIFF
--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -47,6 +47,9 @@ class StreamHandler:
         self._ffmpeg = FfmpegSupervisor(on_restarted=self._reattach_ruark)
         # Метаданные текущего потока для дисплея Ruark: (title, artist)
         self._now_playing: tuple[str, str] = (DEFAULT_STREAM_TITLE, "")
+        # Поколение клиента: новый слушатель вытесняет предыдущего,
+        # иначе два читателя одного pipe рвут поток на куски
+        self._client_epoch = 0
 
     async def execute_with_lock(
         self,
@@ -145,6 +148,10 @@ class StreamHandler:
             raise HTTPException(status_code=404, detail="Поток не запущен")
         stdout = proc.stdout
 
+        # Новый клиент вытесняет предыдущего: единственный читатель pipe
+        self._client_epoch += 1
+        client_epoch = self._client_epoch
+
         async def generate():
             try:
                 empty_count = 0
@@ -154,6 +161,13 @@ class StreamHandler:
                 serve_started = time.monotonic()
                 first_chunk_sent = False
                 while True:
+                    if self._client_epoch != client_epoch:
+                        logger.info(
+                            "⏹ Подключился новый клиент — закрываем "
+                            "старое соединение"
+                        )
+                        break
+
                     # Выход после полной передачи stdout
                     if stdout.at_eof():
                         logger.info(

--- a/tests/test_stream_handler.py
+++ b/tests/test_stream_handler.py
@@ -166,3 +166,28 @@ async def test_play_stream_passes_metadata_to_ruark():
     assert call.kwargs["title"] == "Песня"
     assert call.kwargs["artist"] == "Артист"
     await handler.stop_ffmpeg()
+
+
+async def read_chunk(agen, timeout=3.0):
+    """Читает следующий чанк из генератора стрима с таймаутом."""
+    return await asyncio.wait_for(agen.__anext__(), timeout)
+
+
+async def test_new_client_displaces_previous_stream():
+    handler, _ = make_handler()
+    set_params(handler, ["sh", "-c", "while :; do printf A; sleep 0.05; done"])
+    await handler.start_ffmpeg_stream("http://example/one")
+
+    first = (await handler.stream_audio()).body_iterator
+    assert await read_chunk(first)
+
+    # Второй клиент (переподключение Ruark) забирает поток себе
+    second = (await handler.stream_audio()).body_iterator
+    assert await read_chunk(second)
+
+    # Первый закрывается и больше не ворует байты из pipe
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(first.__anext__(), timeout=3.0)
+
+    await second.aclose()
+    await handler.stop_ffmpeg()


### PR DESCRIPTION
## Проблема

Периодически звук на Ruark становился «перегруженным»/битым до рестарта стрима. По логам: Ruark переподключается к /live_stream.mp3 (после перепривязок и сетевых пауз), а старое соединение остаётся живым — сервер не знает о мёртвом абоненте, пока TCP не упрётся. Два генератора читают один pipe FFmpeg, каждый получает дырявый поток — отсюда хрип, который не проходит сам.

## Решение

Политика «один активный слушатель»: каждое подключение получает номер поколения; генератор при каждой итерации проверяет, не появился ли клиент новее, и закрывается. Переподключившийся Ruark мгновенно становится единственным читателем; максимум, что успеет украсть старое соединение — один чанк в 4КБ.