### PR TITLE
feat: lossless FLAC с фолбэком на MP3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,5 +55,5 @@ check_untyped_defs = true
 disallow_any_generics = true
 
 [[tool.mypy.overrides]]
-module = ["upnpclient", "upnpclient.*", "yandex_music"]
+module = ["upnpclient", "upnpclient.*", "yandex_music", "yandex_music.*"]
 ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pydantic==2.10.6
 pydantic-settings==2.8.1
 upnpclient==1.0.3
 uvicorn==0.34.0
-yandex-music==2.2.0
+yandex-music==3.0.0
 zeroconf==0.146.1

--- a/src/core/config/settings.py
+++ b/src/core/config/settings.py
@@ -40,6 +40,8 @@ class Settings(BaseSettings):
     # Stream settings
     stream_quality: str = "192"
     stream_is_local_file: bool = False
+    # Предпочитать lossless (FLAC), когда он доступен для трека
+    prefer_lossless: bool = True
 
 
 settings = Settings()

--- a/src/dlna_stream_server/endpoints/stream.py
+++ b/src/dlna_stream_server/endpoints/stream.py
@@ -28,11 +28,12 @@ async def _handle_stream_task(
     start_position: float = 0.0,
     title: str = "",
     artist: str = "",
+    codec: str = "mp3",
 ):
     """Обработчик задачи потока с логированием ошибок."""
     try:
         await stream_handler.play_stream(
-            yandex_url, radio, start_position, title, artist
+            yandex_url, radio, start_position, title, artist, codec
         )
         logger.info(f"✅ Задача потока {task_id} завершена успешно")
     except Exception as e:
@@ -50,6 +51,7 @@ async def set_stream(
     start_position: float = 0.0,
     title: str = "",
     artist: str = "",
+    codec: str = "mp3",
 ):
     """Принимает URL трека и запускает потоковую передачу на Ruark.
 
@@ -82,6 +84,7 @@ async def set_stream(
             start_position,
             title,
             artist,
+            codec,
         )
     )
     _active_tasks[task_id] = task
@@ -101,10 +104,10 @@ async def serve_stream(request: Request, radio: bool = False):
 
 
 @router.head("/live_stream.mp3")
-async def serve_head(radio: bool = False):
+async def serve_head(request: Request, radio: bool = False):
     """Обрабатывает HEAD-запрос для Ruark R5 с корректными заголовками."""
     headers = {
-        "Content-Type": "audio/mpeg" if not radio else "audio/aac",
+        "Content-Type": _get_stream_handler(request).stream_media_type,
         "Accept-Ranges": "bytes",
         "Connection": "keep-alive",
     }

--- a/src/dlna_stream_server/handlers/constants.py
+++ b/src/dlna_stream_server/handlers/constants.py
@@ -94,3 +94,36 @@ FFMPEG_AAC_PARAMS = [
     "2M",
     "pipe:1",
 ]
+
+# Параметры для lossless: перепаковка FLAC из MP4-контейнера
+# в чистый FLAC-поток без перекодирования
+FFMPEG_FLAC_PARAMS = [
+    "ffmpeg",
+    "-rw_timeout",
+    "30000000",
+    "-reconnect",
+    "1",
+    "-reconnect_streamed",
+    "1",
+    "-reconnect_delay_max",
+    "1",
+    "-thread_queue_size",
+    "4096",
+    "-i",
+    "{yandex_url}",
+    "-vn",
+    "-map_metadata",
+    "-1",
+    "-c:a",
+    "copy",
+    "-f",
+    "flac",
+    "pipe:1",
+]
+
+# MIME-типы потоков по кодеку
+STREAM_MIME_TYPES = {
+    "mp3": "audio/mpeg",
+    "flac": "audio/flac",
+    "aac": "audio/aac",
+}

--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -14,8 +14,10 @@ from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 
 from .constants import (
     FFMPEG_AAC_PARAMS,
+    FFMPEG_FLAC_PARAMS,
     FFMPEG_LOCAL_MP3_PARAMS,
     FFMPEG_MP3_PARAMS,
+    STREAM_MIME_TYPES,
 )
 from .ffmpeg_supervisor import FfmpegSupervisor
 
@@ -47,9 +49,16 @@ class StreamHandler:
         self._ffmpeg = FfmpegSupervisor(on_restarted=self._reattach_ruark)
         # Метаданные текущего потока для дисплея Ruark: (title, artist)
         self._now_playing: tuple[str, str] = (DEFAULT_STREAM_TITLE, "")
+        # Кодек текущего потока: mp3 | flac | aac (радио)
+        self._stream_codec = "mp3"
         # Поколение клиента: новый слушатель вытесняет предыдущего,
         # иначе два читателя одного pipe рвут поток на куски
         self._client_epoch = 0
+
+    @property
+    def stream_media_type(self) -> str:
+        """MIME-тип текущего потока."""
+        return STREAM_MIME_TYPES[self._stream_codec]
 
     async def execute_with_lock(
         self,
@@ -92,6 +101,7 @@ class StreamHandler:
             track_url,
             title=title,
             artist=artist,
+            mime_type=self.stream_media_type,
         )
         await self.execute_with_lock(self._ruark_controls.play)
 
@@ -104,6 +114,7 @@ class StreamHandler:
         yandex_url: str,
         radio: bool = False,
         start_position: float = 0.0,
+        codec: str = "mp3",
     ) -> None:
         """Готовит источник и запускает потоковую передачу через FFmpeg.
 
@@ -111,6 +122,7 @@ class StreamHandler:
             yandex_url (str): Прямая ссылка на источник потока.
             radio (bool): Режим радио.
             start_position (float): Позиция старта трека в секундах.
+            codec (str): Кодек трека: mp3 или flac (lossless).
         """
         # Очищаем папку от старых MP3 файлов перед запуском нового стрима
         if not radio and settings.stream_is_local_file:
@@ -120,6 +132,7 @@ class StreamHandler:
             # Мастер-плейлист передаётся FFmpeg как есть: вложенные
             # плейлисты привязаны к сессии (hlssid) и должны запрашиваться
             # тем же клиентом, что получил мастер
+            self._stream_codec = "aac"
             params = self._get_ffmpeg_params(codec="aac")
         else:
             yandex_url = (
@@ -127,9 +140,10 @@ class StreamHandler:
                 if settings.stream_is_local_file
                 else yandex_url
             )
+            self._stream_codec = codec if codec == "flac" else "mp3"
             params = _insert_start_position(
                 self._get_ffmpeg_params(
-                    codec="mp3",
+                    codec=self._stream_codec,
                     is_local_file=settings.stream_is_local_file,
                 ),
                 start_position,
@@ -261,7 +275,7 @@ class StreamHandler:
                 )
                 await self.stop_ffmpeg()
 
-        media_type = "audio/mpeg" if not radio else "audio/aac"
+        media_type = self.stream_media_type
 
         logger.info(f"🎧 Отправляем стрим с типом {media_type}")
 
@@ -274,10 +288,13 @@ class StreamHandler:
         start_position: float = 0.0,
         title: str = "",
         artist: str = "",
+        codec: str = "mp3",
     ) -> None:
         """Запускает потоковую трансляцию и передает её на Ruark."""
         self._now_playing = (title or DEFAULT_STREAM_TITLE, artist)
-        logger.info(f"🎶 Начинаем потоковое воспроизведение {yandex_url}")
+        logger.info(
+            f"🎶 Начинаем потоковое воспроизведение [{codec}] {yandex_url}"
+        )
 
         # Сбрасываем счетчик попыток и флаги для нового потока
         self._ffmpeg.reset_restart_state()
@@ -285,7 +302,9 @@ class StreamHandler:
         try:
             play_started = time.monotonic()
             # Запускаем потоковую передачу (быстро, без ожидания)
-            await self.start_ffmpeg_stream(yandex_url, radio, start_position)
+            await self.start_ffmpeg_stream(
+                yandex_url, radio, start_position, codec
+            )
             ffmpeg_seconds = time.monotonic() - play_started
 
             track_url = self._local_stream_url(radio)
@@ -358,6 +377,8 @@ class StreamHandler:
             return (
                 FFMPEG_LOCAL_MP3_PARAMS if is_local_file else FFMPEG_MP3_PARAMS
             )
+        elif codec == "flac":
+            return FFMPEG_FLAC_PARAMS
         elif codec == "aac":
             return FFMPEG_AAC_PARAMS
         else:

--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -346,23 +346,24 @@ class MainStreamManager:
             f"🔁 Ресинк стрима ({reason}): позиция {track.progress:.0f}s"
         )
         resync_started = time.monotonic()
-        track_url = await self._yandex_music_api.get_file_info(
+        source = await self._yandex_music_api.get_track_source(
             track_id=track.id,
             quality=settings.stream_quality,
         )
-        if not track_url:
+        if not source:
             logger.warning("⚠️ Не удалось получить URL трека для ресинка")
             return
 
-        ctx.track_url = track_url
+        ctx.track_url = source.url
         ctx.last_track = track
         ctx.last_stream_sent_at = time.monotonic()
         await self._send_track_to_stream_server(
-            track_url,
+            source.url,
             radio=False,
             start_position=track.progress,
             title=track.title,
             artist=track.artist,
+            codec=source.codec,
         )
         logger.info(
             f"⏱ Ресинк выполнен за "
@@ -381,14 +382,17 @@ class MainStreamManager:
             return
 
         switch_started = time.monotonic()
+        codec = "mp3"
         if track.type == "FmRadio":
             ctx.track_url = await self._station_controls.get_radio_url()
             logger.info(f"🎵 URL радиостанции: {ctx.track_url}")
         else:
-            ctx.track_url = await self._yandex_music_api.get_file_info(
+            source = await self._yandex_music_api.get_track_source(
                 track_id=track.id,
                 quality=settings.stream_quality,
             )
+            ctx.track_url = source.url if source else None
+            codec = source.codec if source else "mp3"
         resolve_seconds = time.monotonic() - switch_started
 
         if ctx.track_url:
@@ -410,6 +414,7 @@ class MainStreamManager:
                 start_position=start_position,
                 title=track.title,
                 artist=track.artist,
+                codec=codec,
             )
             logger.info(
                 f"⏱ Переключение на {track.id}: ссылка "
@@ -552,6 +557,7 @@ class MainStreamManager:
         start_position: float = 0.0,
         title: str = "",
         artist: str = "",
+        codec: str = "mp3",
     ):
         """Отправляет ссылку на трек на стрим сервер.
 
@@ -561,6 +567,7 @@ class MainStreamManager:
             start_position (float): Позиция старта в секундах.
             title (str): Название трека для дисплея Ruark.
             artist (str): Исполнитель для дисплея Ruark.
+            codec (str): Кодек источника: mp3 или flac.
         """
         try:
             timeout = aiohttp.ClientTimeout(total=15)
@@ -575,6 +582,7 @@ class MainStreamManager:
                         "start_position": f"{start_position:.1f}",
                         "title": title,
                         "artist": artist,
+                        "codec": codec,
                     },
                 ) as resp:
                     response = await resp.json()

--- a/src/main_stream_service/yandex_music_api.py
+++ b/src/main_stream_service/yandex_music_api.py
@@ -1,8 +1,35 @@
+import base64
+import hashlib
+import hmac
 import logging
+import time
+from dataclasses import dataclass
 
+import aiohttp
 from yandex_music import ClientAsync
+from yandex_music.utils.sign_request import DEFAULT_SIGN_KEY
+
+from core.config.settings import settings
 
 logger = logging.getLogger(__name__)
+
+GET_FILE_INFO_URL = "https://api.music.yandex.net/get-file-info"
+
+# Заголовки официального клиента: без них get-file-info отвечает 403
+MUSIC_CLIENT_HEADERS = {
+    "User-Agent": "Yandex-Music-API",
+    "X-Yandex-Music-Client": "YandexMusicAndroid/24023621",
+}
+
+LOSSLESS_CODECS = "flac,flac-mp4,mp3,aac,he-aac,aac-mp4,he-aac-mp4"
+
+
+@dataclass
+class TrackSource:
+    """Источник потока трека: прямая ссылка и кодек."""
+
+    url: str
+    codec: str  # "flac" | "mp3"
 
 
 class YandexMusicAPI:
@@ -12,6 +39,87 @@ class YandexMusicAPI:
 
     def __init__(self, client: ClientAsync):
         self._client = client
+
+    async def get_track_source(
+        self,
+        track_id: str | int,
+        quality: str | None = None,
+    ) -> TrackSource | None:
+        """Возвращает лучший источник трека: FLAC, если доступен, иначе MP3.
+
+        Args:
+            track_id (str | int): Идентификатор трека.
+            quality (str | None): Битрейт MP3 для фолбэка, kbps.
+        Returns:
+            TrackSource | None: Ссылка и кодек или None, если недоступно.
+        """
+        if settings.prefer_lossless:
+            lossless_url = await self._get_lossless_url(track_id)
+            if lossless_url:
+                return TrackSource(url=lossless_url, codec="flac")
+
+        mp3_url = await self.get_file_info(track_id, quality=quality)
+        if mp3_url:
+            return TrackSource(url=mp3_url, codec="mp3")
+        return None
+
+    async def _get_lossless_url(self, track_id: str | int) -> str | None:
+        """Запрашивает прямую lossless-ссылку через get-file-info.
+
+        Подписанный запрос к новому API; транспорт raw отдаёт
+        нешифрованный поток (codec flac-mp4). Любая ошибка означает
+        фолбэк на MP3, поэтому наружу не пробрасывается.
+        """
+        try:
+            params: dict[str, str | int] = {
+                "ts": int(time.time()),
+                "trackId": str(track_id),
+                "quality": "lossless",
+                "codecs": LOSSLESS_CODECS,
+                "transports": "raw",
+            }
+            message = "".join(str(v) for v in params.values()).replace(",", "")
+            digest = hmac.new(
+                DEFAULT_SIGN_KEY.encode(),
+                message.encode(),
+                hashlib.sha256,
+            ).digest()
+            params["sign"] = base64.b64encode(digest).decode()[:-1]
+
+            headers = dict(MUSIC_CLIENT_HEADERS)
+            headers["Authorization"] = f"OAuth {settings.ya_music_token}"
+
+            timeout = aiohttp.ClientTimeout(total=10)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    GET_FILE_INFO_URL, params=params, headers=headers
+                ) as response:
+                    if response.status != 200:
+                        logger.info(
+                            f"ℹ️ Lossless недоступен для {track_id}: "
+                            f"HTTP {response.status}"
+                        )
+                        return None
+                    body = await response.json()
+
+            info = (body.get("result") or {}).get("downloadInfo") or {}
+            codec = str(info.get("codec", ""))
+            urls = info.get("urls") or []
+            if not codec.startswith("flac") or not urls:
+                logger.info(
+                    f"ℹ️ Lossless для {track_id} не выдан "
+                    f"(codec={codec or 'нет'})"
+                )
+                return None
+
+            logger.info(f"💎 Lossless источник для {track_id}: {codec}")
+            return str(urls[0])
+        except Exception as e:
+            logger.warning(
+                f"⚠️ Ошибка запроса lossless для {track_id}: {e} — "
+                f"фолбэк на MP3"
+            )
+            return None
 
     async def get_file_info(
         self,

--- a/src/ruark_audio_system/constants.py
+++ b/src/ruark_audio_system/constants.py
@@ -6,7 +6,7 @@ META_INFO = """<?xml version="1.0" encoding="utf-8"?>
     <dc:title>{title}</dc:title>
     <dc:creator>{artist}</dc:creator>
     <upnp:artist>{artist}</upnp:artist>
-    <res protocolInfo="http-get:*:audio/mpeg:*"
+    <res protocolInfo="http-get:*:{mime_type}:*"
          duration="24:00:00.000">{url}</res>
     <upnp:class>object.item.audioItem.audioBroadcast</upnp:class>
     <upnp:radioCallSign>Yandex Music</upnp:radioCallSign>

--- a/src/ruark_audio_system/ruark_r5_controller.py
+++ b/src/ruark_audio_system/ruark_r5_controller.py
@@ -202,10 +202,11 @@ class RuarkR5Controller:
         uri: str,
         title: str = DEFAULT_STREAM_TITLE,
         artist: str = "",
+        mime_type: str = "audio/mpeg",
     ) -> None:
         """Установка нового потока с метаданными для дисплея."""
         metadata = self.generate_metadata_with_fake_duration(
-            uri, title=title, artist=artist
+            uri, title=title, artist=artist, mime_type=mime_type
         )
         await asyncio.to_thread(
             self.av_transport.SetAVTransportURI,
@@ -402,6 +403,7 @@ class RuarkR5Controller:
         uri: str,
         title: str = DEFAULT_STREAM_TITLE,
         artist: str = "",
+        mime_type: str = "audio/mpeg",
     ) -> str:
         """Генерация DIDL-Lite метаданных с длительностью 24 часа.
 
@@ -414,6 +416,7 @@ class RuarkR5Controller:
             url=escape(uri),
             title=escape(display_title),
             artist=escape(artist),
+            mime_type=escape(mime_type),
         )
 
     async def print_status(self) -> None:

--- a/src/yandex_station/station_controls.py
+++ b/src/yandex_station/station_controls.py
@@ -150,7 +150,7 @@ class YandexStationControls:
             volume = state.get("state", {}).get("volume")
             if volume is None:
                 return None
-            logger.info(
+            logger.debug(
                 f"🔊 Получение текущего уровня громкости Алиcы: {volume}"
             )
             return float(volume)

--- a/tests/test_stream_handler.py
+++ b/tests/test_stream_handler.py
@@ -191,3 +191,27 @@ async def test_new_client_displaces_previous_stream():
 
     await second.aclose()
     await handler.stop_ffmpeg()
+
+
+async def test_flac_codec_selects_flac_params_and_mime():
+    handler, ruark = make_handler()
+
+    await handler.play_stream(
+        "http://example/track.flac", codec="flac", title="Т", artist="А"
+    )
+
+    assert handler.stream_media_type == "audio/flac"
+    call = ruark.set_av_transport_uri.call_args
+    assert call.kwargs["mime_type"] == "audio/flac"
+    await handler.stop_ffmpeg()
+
+
+def test_ffmpeg_params_for_flac_remux_without_reencode():
+    from dlna_stream_server.handlers.constants import FFMPEG_FLAC_PARAMS
+
+    handler, _ = make_handler()
+    params = handler._get_ffmpeg_params(codec="flac")
+
+    assert params is FFMPEG_FLAC_PARAMS
+    assert "copy" in params
+    assert "flac" in params

--- a/tests/test_streaming_loop.py
+++ b/tests/test_streaming_loop.py
@@ -8,7 +8,7 @@ from main_stream_service.main_stream_manager import (
     MainStreamManager,
     _CycleContext,
 )
-from main_stream_service.yandex_music_api import YandexMusicAPI
+from main_stream_service.yandex_music_api import TrackSource, YandexMusicAPI
 from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 from yandex_station.constants import (
     RUARK_IDLE_VOLUME,
@@ -86,6 +86,9 @@ def make_ruark(is_playing=True, volume=20):
 def make_manager(station_controls, ruark, track_url="http://track/url"):
     music_api = AsyncMock(spec=YandexMusicAPI)
     music_api.get_file_info.return_value = track_url
+    music_api.get_track_source.return_value = (
+        TrackSource(url=track_url, codec="mp3") if track_url else None
+    )
     ws_client = MagicMock()
 
     # Без событий цикл живёт на heartbeat; передача управления
@@ -127,8 +130,8 @@ async def test_new_track_sent_to_stream_server(fast_sleep):
         manager, until=lambda: manager._send_track_to_stream_server.called
     )
 
-    manager._yandex_music_api.get_file_info.assert_called()
-    call = manager._yandex_music_api.get_file_info.call_args
+    manager._yandex_music_api.get_track_source.assert_called()
+    call = manager._yandex_music_api.get_track_source.call_args
     assert call.kwargs["track_id"] == "42"
     send_call = manager._send_track_to_stream_server.call_args_list[0]
     assert send_call.args[0] == "http://track/url"

--- a/tests/test_yandex_music_api.py
+++ b/tests/test_yandex_music_api.py
@@ -55,3 +55,41 @@ async def test_get_file_info_returns_none_without_track():
     client.tracks = AsyncMock(return_value=[])
     api = YandexMusicAPI(client=client)
     assert await api.get_file_info(1) is None
+
+
+async def test_get_track_source_prefers_lossless(monkeypatch):
+    api = make_api([info("mp3", 320, "link-320")])
+    lossless_mock = AsyncMock(return_value="https://cdn/flac-url")
+    monkeypatch.setattr(api, "_get_lossless_url", lossless_mock)
+
+    source = await api.get_track_source("42", quality="320")
+
+    assert source is not None
+    assert source.codec == "flac"
+    assert source.url == "https://cdn/flac-url"
+
+
+async def test_get_track_source_falls_back_to_mp3(monkeypatch):
+    api = make_api([info("mp3", 320, "link-320")])
+    monkeypatch.setattr(api, "_get_lossless_url", AsyncMock(return_value=None))
+
+    source = await api.get_track_source("42", quality="320")
+
+    assert source is not None
+    assert source.codec == "mp3"
+    assert source.url == "link-320"
+
+
+async def test_get_track_source_skips_lossless_when_disabled(monkeypatch):
+    from core.config.settings import settings
+
+    monkeypatch.setattr(settings, "prefer_lossless", False)
+    api = make_api([info("mp3", 320, "link-320")])
+    lossless_mock = AsyncMock(return_value="https://cdn/flac-url")
+    monkeypatch.setattr(api, "_get_lossless_url", lossless_mock)
+
+    source = await api.get_track_source("42", quality="320")
+
+    assert source is not None
+    assert source.codec == "mp3"
+    lossless_mock.assert_not_awaited()


### PR DESCRIPTION
## Что сделано

Для каждого трека система теперь пытается получить lossless (FLAC) и падает обратно на MP3-320, если lossless для трека недоступен.

### Разведка (проверено вживую)
- новый API `get-file-info` с HMAC-подписью и клиентскими заголовками отдаёт lossless: `codec=flac-mp4`, 44.1кГц/16бит
- транспорт `raw` даёт прямую **нешифрованную** ссылку — AES-расшифровка не нужна
- FFmpeg перепаковывает FLAC из MP4-контейнера в чистый FLAC-поток без перекодирования (`-c:a copy -f flac`), перемотка `-ss` работает

### Реализация
- `YandexMusicAPI.get_track_source` → `TrackSource(url, codec)`: lossless → фолбэк MP3; любые ошибки lossless-пути тихо уводят на MP3
- кодек едет по цепочке до FFmpeg-профиля (`FFMPEG_FLAC_PARAMS`) и MIME-типов: HTTP-заголовки потока и `protocolInfo` в DIDL-Lite (`audio/flac`)
- `APP_PREFER_LOSSLESS=false` полностью отключает lossless-путь
- `yandex-music` 2.2.0 → 3.0.0

### Проверки
73 теста (5 новых), mypy strict — 0 ошибок, flake8 чисто. Живой smoke: `prefer_lossless=True → flac`, `False → mp3`.

## Проверка локально — ключевой вопрос: примет ли Ruark FLAC-поток
1. Включить трек — в логе `💎 Lossless источник`, на Ruark играет FLAC (в UI Ruark может показать формат).
2. Переключение, перемотка, пауза — как обычно.
3. Радио — без изменений (aac).
4. Если Ruark не заиграет FLAC — `APP_PREFER_LOSSLESS=false` возвращает всё как было, обсудим транскод в WAV/PCM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)