### PR TITLE
fix: тест FLAC не зависит от системного ffmpeg

### DIFF
--- a/tests/test_stream_handler.py
+++ b/tests/test_stream_handler.py
@@ -195,6 +195,8 @@ async def test_new_client_displaces_previous_stream():
 
 async def test_flac_codec_selects_flac_params_and_mime():
     handler, ruark = make_handler()
+    # Фейковая команда: на CI-раннере нет ffmpeg
+    set_params(handler, ["sleep", "30"])
 
     await handler.play_stream(
         "http://example/track.flac", codec="flac", title="Т", artist="А"


### PR DESCRIPTION
Тест test_flac_codec_selects_flac_params_and_mime запускал настоящий ffmpeg — на GitHub-раннере его нет, CI падал, деплой FLAC (мерж PR #28) не доехал до Raspberry. Тест переведён на фейковую команду, как остальные тесты хендлера; выбор параметров по кодеку покрыт отдельным чистым тестом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)