### PR TITLE
fix: корректное поведение при выключенном Ruark

### DIFF
--- a/src/main_stream_service/main_stream_manager.py
+++ b/src/main_stream_service/main_stream_manager.py
@@ -2,6 +2,7 @@ import asyncio
 import time
 from dataclasses import dataclass
 from logging import getLogger
+from typing import Any, Awaitable, Callable
 
 import aiohttp
 from injector import inject
@@ -78,6 +79,8 @@ class MainStreamManager:
         self._volume_store = RuarkVolumeStore()
         self._stream_state_running = False
         self._tasks = []  # Хранение фоновых задач
+        # Ссылка на задачу авто-остановки (Ruark выключен пользователем)
+        self._shutdown_task: asyncio.Task[None] | None = None
 
     async def start(self):
         """Запуск всех стриминговых процессов."""
@@ -107,14 +110,21 @@ class MainStreamManager:
         self._tasks.extend([stream_task])
 
     async def stop(self):
-        """Остановка всех стриминговых процессов."""
+        """Остановка всех стриминговых процессов.
+
+        Каждый шаг с устройствами выполняется независимо: недоступный
+        Ruark (например, выключен пользователем) не должен прерывать
+        возврат звука на станцию и остановку фоновых задач.
+        """
         logger.info("🛑 Остановка стриминга...")
         self._stream_state_running = False
         await self._remember_ruark_volume()
-        await self._ruark_controls.stop()
-        await self._stop_stream_on_stream_server()
-        await self._ruark_controls.set_volume(self._ruark_volume)
-        await self._ruark_controls.turn_power_off()
+        await self._safe_stop_step(self._ruark_controls.stop)
+        await self._safe_stop_step(self._stop_stream_on_stream_server)
+        await self._safe_stop_step(
+            self._ruark_controls.set_volume, self._ruark_volume
+        )
+        await self._safe_stop_step(self._ruark_controls.turn_power_off)
         await self._station_controls.unmute()
         # Остановка WebSocket-клиента
         await self._station_controls.stop_ws_client()
@@ -126,6 +136,19 @@ class MainStreamManager:
         await asyncio.gather(*self._tasks, return_exceptions=True)
         self._tasks.clear()
         logger.info("✅ Стриминг остановлен")
+
+    async def _safe_stop_step(
+        self,
+        func: Callable[..., Awaitable[Any]],
+        *args: Any,
+    ) -> None:
+        """Выполняет шаг остановки, не прерывая её при недоступности."""
+        try:
+            await func(*args)
+        except Exception as e:
+            logger.warning(
+                f"⚠️ Шаг остановки {func.__name__} не выполнен: {e}"
+            )
 
     async def streaming(self):
         """Основной поток управления стримингом."""
@@ -335,8 +358,29 @@ class MainStreamManager:
             return
 
         ctx.silent_checks = 0
+        if await self._is_ruark_powered_off():
+            logger.warning(
+                "🔌 Ruark выключен пользователем — останавливаем стриминг, "
+                "звук возвращается на станцию"
+            )
+            # stop() отменяет и задачу цикла, поэтому запускается отдельно
+            self._shutdown_task = asyncio.create_task(self.stop())
+            return
+
         logger.warning("⚠️ Станция играет, а Ruark молчит — пересылаем поток")
         await self._resend_current_track(track, ctx, "страховка от тишины")
+
+    async def _is_ruark_powered_off(self) -> bool:
+        """Проверяет, выключено ли питание Ruark.
+
+        Ошибка запроса трактуется как «не выключен»: недоступный fsapi
+        не должен останавливать стриминг.
+        """
+        try:
+            return await self._ruark_controls.get_power_status() == "0"
+        except Exception as e:
+            logger.debug(f"Не удалось узнать питание Ruark: {e}")
+            return False
 
     async def _resend_current_track(
         self, track: Track, ctx: "_CycleContext", reason: str

--- a/tests/test_streaming_loop.py
+++ b/tests/test_streaming_loop.py
@@ -373,3 +373,47 @@ async def test_playing_ruark_does_not_trigger_resend(fast_sleep, monkeypatch):
 
     # Только первоначальный свитч, страховка молчит
     assert send.call_count == 1
+
+
+async def test_powered_off_ruark_stops_streaming(fast_sleep, monkeypatch):
+    """Ruark выключен пользователем — стриминг останавливается сам."""
+    monkeypatch.setattr(
+        "main_stream_service.main_stream_manager.SILENCE_RESEND_GRACE", 0.0
+    )
+    monkeypatch.setattr(
+        "main_stream_service.main_stream_manager.SILENCE_CHECK_INTERVAL", 0.0
+    )
+    track = make_track(progress=50.0)
+    station = make_station_controls(track)
+    ruark = make_ruark(is_playing=False)
+    ruark.get_power_status.return_value = "0"
+    manager = make_manager(station, ruark)
+    manager._stop_stream_on_stream_server = AsyncMock()
+    send = manager._send_track_to_stream_server
+
+    await drive_streaming(
+        manager, until=lambda: not manager._stream_state_running
+    )
+
+    assert manager._stream_state_running is False
+    # Поток не пересылался выключенному устройству
+    assert send.call_count == 1  # только первоначальный свитч
+    station.unmute.assert_called()
+
+
+async def test_stop_survives_unreachable_ruark():
+    """Недоступный Ruark не прерывает остановку стриминга."""
+    station = make_station_controls(make_track())
+    ruark = make_ruark()
+    ruark.stop.side_effect = RuntimeError("нет связи")
+    ruark.set_volume.side_effect = RuntimeError("нет связи")
+    ruark.turn_power_off.side_effect = RuntimeError("нет связи")
+    manager = make_manager(station, ruark)
+    manager._stop_stream_on_stream_server = AsyncMock()
+    manager._volume_store = MagicMock()
+
+    await manager.stop()
+
+    # Главные шаги дошли до конца, несмотря на мёртвый Ruark
+    station.unmute.assert_called()
+    station.stop_ws_client.assert_called()


### PR DESCRIPTION
## Проблема

Если выключить Ruark кнопкой, не выключая стрим, страховка от тишины бесконечно пересылала поток мёртвому устройству (is_playing → False → resend → по кругу каждые ~20с). Кроме того, /shutdown при недоступном Ruark мог упасть на середине, не вернув звук на станцию.