### PR TITLE
fix: радио объявляется Ruark как audio/mpeg в DIDL-метаданных

### DIFF
--- a/src/dlna_stream_server/handlers/constants.py
+++ b/src/dlna_stream_server/handlers/constants.py
@@ -121,9 +121,18 @@ FFMPEG_FLAC_PARAMS = [
     "pipe:1",
 ]
 
-# MIME-типы потоков по кодеку
+# MIME-типы потоков по кодеку (Content-Type HTTP-ответа)
 STREAM_MIME_TYPES = {
     "mp3": "audio/mpeg",
     "flac": "audio/flac",
     "aac": "audio/aac",
+}
+
+# MIME-типы для protocolInfo в DIDL-метаданных привязки Ruark.
+# Ресурс, объявленный как audio/aac, Ruark качает, но не воспроизводит —
+# ADTS-поток радио играет только под вывеской audio/mpeg
+DIDL_MIME_TYPES = {
+    "mp3": "audio/mpeg",
+    "flac": "audio/flac",
+    "aac": "audio/mpeg",
 }

--- a/src/dlna_stream_server/handlers/stream_handler.py
+++ b/src/dlna_stream_server/handlers/stream_handler.py
@@ -13,6 +13,7 @@ from ruark_audio_system.constants import DEFAULT_STREAM_TITLE
 from ruark_audio_system.ruark_r5_controller import RuarkR5Controller
 
 from .constants import (
+    DIDL_MIME_TYPES,
     FFMPEG_AAC_PARAMS,
     FFMPEG_FLAC_PARAMS,
     FFMPEG_LOCAL_MP3_PARAMS,
@@ -60,6 +61,11 @@ class StreamHandler:
         """MIME-тип текущего потока."""
         return STREAM_MIME_TYPES[self._stream_codec]
 
+    @property
+    def didl_media_type(self) -> str:
+        """MIME-тип потока для protocolInfo в DIDL-метаданных Ruark."""
+        return DIDL_MIME_TYPES[self._stream_codec]
+
     async def execute_with_lock(
         self,
         func: Callable[..., Awaitable[Any]],
@@ -101,7 +107,7 @@ class StreamHandler:
             track_url,
             title=title,
             artist=artist,
-            mime_type=self.stream_media_type,
+            mime_type=self.didl_media_type,
         )
         await self.execute_with_lock(self._ruark_controls.play)
 

--- a/tests/test_stream_handler.py
+++ b/tests/test_stream_handler.py
@@ -193,6 +193,25 @@ async def test_new_client_displaces_previous_stream():
     await handler.stop_ffmpeg()
 
 
+async def test_radio_declared_as_mpeg_in_didl(fast_sleep):
+    """Радио: Content-Type остаётся aac, но в DIDL — audio/mpeg.
+
+    Ресурс с protocolInfo audio/aac Ruark качает, но не воспроизводит —
+    регрессия радио после перехода на mime по кодеку.
+    """
+    handler, ruark = make_handler()
+    set_params(handler, ["sleep", "30"])
+
+    await handler.play_stream(
+        "http://example/master.m3u8", radio=True, title="ROCK FM"
+    )
+
+    assert handler.stream_media_type == "audio/aac"
+    call = ruark.set_av_transport_uri.call_args
+    assert call.kwargs["mime_type"] == "audio/mpeg"
+    await handler.stop_ffmpeg()
+
+
 async def test_flac_codec_selects_flac_params_and_mime():
     handler, ruark = make_handler()
     # Фейковая команда: на CI-раннере нет ffmpeg


### PR DESCRIPTION
## Контекст

Главный фикс радио, не успевший в PR #35 (был запушен в ветку уже после мержа). Без него радио по-прежнему не заиграет: PR #35 убрал шторм перепривязок, но корень регрессии — в mime.

## Проблема

С PR #28 (FLAC) protocolInfo в DIDL-метаданных подставляется по кодеку, и радио стало объявляться как `audio/aac`. Ruark такой ресурс **качает, но не воспроизводит**: в dlna.log видно привязку, подключение (UA NSPlayer) и 272 КБ переданных данных без перехода в PLAYING. До PR #28 protocolInfo был жёстко `audio/mpeg` — и ADTS-поток радио под этой вывеской играл.