### PR TITLE
fix: MP3-фолбэк не подсовывает AAC-поток в MP3-контейнер

### DIFF
--- a/src/main_stream_service/yandex_music_api.py
+++ b/src/main_stream_service/yandex_music_api.py
@@ -58,9 +58,19 @@ class YandexMusicAPI:
             if lossless_url:
                 return TrackSource(url=lossless_url, codec="flac")
 
-        mp3_url = await self.get_file_info(track_id, quality=quality)
+        # Только MP3: без фильтра «лучшим по битрейту» может оказаться
+        # AAC, а его копирование в MP3-контейнер роняет FFmpeg
+        mp3_url = await self.get_file_info(
+            track_id, quality=quality, codecs="mp3"
+        )
         if mp3_url:
             return TrackSource(url=mp3_url, codec="mp3")
+
+        # У трека нет MP3 вовсе — разово спасаемся lossless
+        if not settings.prefer_lossless:
+            lossless_url = await self._get_lossless_url(track_id)
+            if lossless_url:
+                return TrackSource(url=lossless_url, codec="flac")
         return None
 
     async def _get_lossless_url(self, track_id: str | int) -> str | None:

--- a/tests/test_yandex_music_api.py
+++ b/tests/test_yandex_music_api.py
@@ -80,6 +80,46 @@ async def test_get_track_source_falls_back_to_mp3(monkeypatch):
     assert source.url == "link-320"
 
 
+async def test_get_track_source_ignores_aac_masquerading_as_best(
+    monkeypatch,
+):
+    """Без MP3-320 лучшим по битрейту был бы AAC — берём лучший MP3."""
+    from core.config.settings import settings
+
+    monkeypatch.setattr(settings, "prefer_lossless", False)
+    api = make_api(
+        [
+            info("aac", 256, "link-aac-256"),
+            info("mp3", 192, "link-mp3-192"),
+        ]
+    )
+
+    source = await api.get_track_source("42", quality="320")
+
+    assert source is not None
+    assert source.codec == "mp3"
+    assert source.url == "link-mp3-192"
+
+
+async def test_get_track_source_rescues_with_lossless_without_mp3(
+    monkeypatch,
+):
+    """У трека нет MP3 вовсе — разовый фолбэк на lossless."""
+    from core.config.settings import settings
+
+    monkeypatch.setattr(settings, "prefer_lossless", False)
+    api = make_api([info("aac", 256, "link-aac-256")])
+    monkeypatch.setattr(
+        api, "_get_lossless_url", AsyncMock(return_value="https://cdn/flac")
+    )
+
+    source = await api.get_track_source("42", quality="320")
+
+    assert source is not None
+    assert source.codec == "flac"
+    assert source.url == "https://cdn/flac"
+
+
 async def test_get_track_source_skips_lossless_when_disabled(monkeypatch):
     from core.config.settings import settings
 


### PR DESCRIPTION
- `get_track_source` запрашивает `get_file_info(..., codecs="mp3")` — «лучший по битрейту» выбирается только среди настоящих MP3 (для трека из инцидента это MP3-192 вместо AAC-256).
- Трек без MP3 вовсе → разовый фолбэк на lossless даже при выключенном `APP_PREFER_LOSSLESS` — один FLAC-трек с риском заикания лучше гарантированной тишины.